### PR TITLE
src: fix invalid arguments to BLAS dgemm calls

### DIFF
--- a/src/ir/ir_printer.cpp
+++ b/src/ir/ir_printer.cpp
@@ -672,7 +672,9 @@ void IRPrinter::visit(const Sort* op) {
 void IRPrinter::visit(const Return* op) {
   doIndent();
   stream << "return ";
-  op->ret.accept(this);
+  if (op->ret.defined()) {
+    op->ret.accept(this);
+  }
   stream << ";\n";
 }
 

--- a/src/ir/ir_rewriter.cpp
+++ b/src/ir/ir_rewriter.cpp
@@ -561,11 +561,15 @@ void IRRewriter::visit(const PackTaskArgs* op) {
 }
 
 void IRRewriter::visit(const Return* op) {
-  Expr ret = rewrite(op->ret);
-  if (ret == op->ret) {
-    stmt = op;
+  if (op->ret.defined()) {
+    Expr ret = rewrite(op->ret);
+    if (ret == op->ret) {
+      stmt = op;
+    } else {
+      stmt = Return::make(ret);
+    }
   } else {
-    stmt = Return::make(ret);
+    stmt = op;
   }
 }
 

--- a/src/ir/ir_visitor.cpp
+++ b/src/ir/ir_visitor.cpp
@@ -271,7 +271,9 @@ void IRVisitor::visit(const Sort* op) {
 }
 
 void IRVisitor::visit(const Return* op) {
-  op->ret.accept(this);
+  if (op->ret.defined()) {
+    op->ret.accept(this);
+  }
 }
 
 }  // namespace ir


### PR DESCRIPTION
This commit fixes a bug where out-of-bounds partition accesses led to
invalid results for matrix multiplies or blas errors. This happens when
uneven division resulted in a divided iteration space going out of
bounds.