### PR TITLE
*: adjust transfers to declare partition bounds at higher level tasks

### DIFF
--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -427,6 +427,8 @@ protected:
   /// loop iterator variable should be incremented when the guard is fired.
   ir::Stmt strideBoundsGuard(Iterator iterator, ir::Expr access, bool incrementPosVar);
 
+  bool anyParentInScope(IndexVar var);
+
 private:
   bool assemble;
   bool compute;
@@ -525,6 +527,7 @@ private:
 
   std::map<IndexVar, std::map<TensorVar, std::vector<std::vector<ir::Expr>>>> derivedBounds;
   IndexVar curDistVar;
+  std::map<IndexVar, std::set<IndexVar>> varsInScope;
   int distLoopDepth = 0;
 
   ir::Expr computingOnPartition;

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -1247,7 +1247,7 @@ static bool compare(std::vector<IndexVar> vars1, std::vector<IndexVar> vars2) {
   return vars1 == vars2;
 }
 
-  IndexVar getRootParent(ProvenanceGraph pg, IndexVar var) {
+IndexVar getRootParent(ProvenanceGraph pg, IndexVar var) {
   auto parents = pg.getParents(var);
   if (parents.empty()) {
     return var;

--- a/test/tests-distributed.cpp
+++ b/test/tests-distributed.cpp
@@ -199,8 +199,7 @@ TEST(distributed, cannonMM) {
       .pushCommUnder(b(i, k), kos)
       .pushCommUnder(c(k, j), kos)
       .pushCommUnder(a(i, j), in)
-      // This can be enabled on Sapling where we have an OpenMP + OpenBLAS build.
-       .swapLeafKernel(il, gemm)
+      .swapLeafKernel(il, gemm)
       ;
 
   auto lowered = lower(stmt, "computeLegion", false, true);


### PR DESCRIPTION
This commit adjusts the strategy for transfers to declare partition
bounds for a transfer at all tasks above the transfer. This effectively
gives the runtime system more information about what tasks are using
what pieces of data, and might avoid false all-to-all communication
patterns. For example, in the Cannon algorithm, blindly giving each node
the full B and C matrix causes the runtime to think that all nodes need
to track all other nodes. If we push the information that a node needs
only the chunk of B on its row at the top level task, then the runtime
can restrict communication to just those nodes. In general, giving more
information about partitions to the runtime should result in better
performance.