### PR TITLE
*: add ability to up front create partitions required for operations

### DIFF
--- a/include/taco/lower/lower.h
+++ b/include/taco/lower/lower.h
@@ -52,6 +52,22 @@ ir::Stmt lower(IndexStmt stmt, std::string functionName,
 // a stall on the resulting FutureMap from execute_index_space.
 ir::Stmt lowerNoWait(IndexStmt stmt, std::string functionName, Lowerer lowerer=Lowerer());
 
+// lowerLegion is a legion specific lowering function that has Legion specific
+// choices for lowering.
+// If partition and compute are true, then the generated code will create the partitions
+// necessary for the computation within the code. If only partition is true, then the
+// generated code will just create top level partitions and return then. If only compute
+// is true, then the generated code will create no top level partitions and operate only
+// on partitions passed in as arguments.
+ir::Stmt lowerLegion(IndexStmt stmt, std::string functionName,
+                     bool partition=true, bool compute=true, bool waitOnFuture=true,
+                     Lowerer lowerer=Lowerer());
+
+// lowerLegionSeparatePartitionCompute lowers an IndexStmt into two separate
+// functions, one that performs all of the partitioning for the statement up front,
+// and another that performs all of the compute given those partitions.
+ir::Stmt lowerLegionSeparatePartitionCompute(IndexStmt stmt, std::string name, bool waitOnFuture=true);
+
 /// Check whether the an index statement can be lowered to C code.  If the
 /// statement cannot be lowered and a `reason` string is provided then it is
 /// filled with the a reason.

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -55,7 +55,9 @@ public:
 
   /// Lower an index statement to an IR function.
   ir::Stmt lower(IndexStmt stmt, std::string name, 
-                 bool assemble, bool compute, bool pack, bool unpack, bool waitOnFutureMap);
+                 bool assemble, bool compute,
+                 bool pack, bool unpack,
+                 bool partition, bool waitOnFutureMap);
 
 protected:
 
@@ -552,6 +554,18 @@ private:
   std::map<IndexVar, std::shared_ptr<LeafCallInterface>> calls;
 
   bool waitOnFutureMap;
+
+  // LegionLoweringKind controls how the lowerer should generate code
+  // for the target statement.
+  enum LegionLoweringKind {
+    PARTITION_AND_COMPUTE,
+    PARTITION_ONLY,
+    COMPUTE_ONLY,
+  };
+  LegionLoweringKind legionLoweringKind;
+  // computeOnlyPartitions holds onto a partition argument for each tensor
+  // when the LegionLoweringKind is COMPUTE_ONLY.
+  std::map<TensorVar, ir::Expr> computeOnlyPartitions;
 };
 
 }

--- a/legion/cannonMM/taco-generated.cpp
+++ b/legion/cannonMM/taco-generated.cpp
@@ -19,56 +19,26 @@ struct task_3Args {
   int32_t gridY;
 };
 struct task_4Args {
+};
+struct task_5Args {
+  int32_t b1_dimension;
+  int32_t b2_dimension;
+  int32_t c2_dimension;
   int32_t gridX;
+  int32_t gridY;
   int32_t in;
   int32_t jn;
   int32_t kos;
 };
-struct task_5Args {
-  int32_t c1_dimension;
+struct task_6Args {
+  int32_t b1_dimension;
+  int32_t b2_dimension;
+  int32_t c2_dimension;
   int32_t gridX;
+  int32_t gridY;
 };
 
-LogicalPartition partitionLegion(Context ctx, Runtime* runtime, LogicalRegion a, int32_t gridX, int32_t gridY) {
-  int a1_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[0] + 1;
-  int a2_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[1] + 1;
-  auto a_index_space = get_index_space(a);
-
-  Point<2> lowerBound = Point<2>(0, 0);
-  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
-  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
-  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
-  auto aDomain = runtime->get_index_space_domain(ctx, a_index_space);
-  DomainPointColoring aColoring = DomainPointColoring();
-  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
-    int32_t in = (*itr)[0];
-    int32_t jn = (*itr)[1];
-    Point<2> aStart = Point<2>((in * ((a1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jn * ((a2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
-    Point<2> aEnd = Point<2>(TACO_MIN((in * ((a1_dimension + (gridX - 1)) / gridX) + ((a1_dimension + (gridX - 1)) / gridX - 1)), aDomain.hi()[0]), TACO_MIN((jn * ((a2_dimension + (gridY - 1)) / gridY) + ((a2_dimension + (gridY - 1)) / gridY - 1)), aDomain.hi()[1]));
-    Rect<2> aRect = Rect<2>(aStart, aEnd);
-    if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
-      aRect = aRect.make_empty();
-    }
-    aColoring[(*itr)] = aRect;
-  }
-  auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  return runtime->get_logical_partition(ctx, get_logical_region(a), aPartition);
-}
-
-void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion a = regions[0];
-
-  int32_t distFused = task->index_point[0];
-  task_1Args* args = (task_1Args*)(task->args);
-  int32_t gridX = args->gridX;
-  int32_t gridY = args->gridY;
-
-
-  int32_t in = getIndexPoint(task, 0);
-  int32_t jn = getIndexPoint(task, 1);
-}
-
-LogicalPartition placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, int32_t gridX, int32_t gridY) {
+std::vector<LogicalPartition> partitionForplaceLegionA(Context ctx, Runtime* runtime, LogicalRegion a, int32_t gridX, int32_t gridY) {
   int a1_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[0] + 1;
   int a2_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[1] + 1;
   auto a_index_space = get_index_space(a);
@@ -91,8 +61,31 @@ LogicalPartition placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, in
     aColoring[(*itr)] = aRect;
   }
   auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_COMPUTE_KIND);
-  LogicalPartition aLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(a), aPartition);
-  RegionRequirement aReq = RegionRequirement(aLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(a));
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(a), aPartition));
+  return computePartitions;
+}
+
+void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion a = regions[0];
+
+  int32_t distFused = task->index_point[0];
+  task_1Args* args = (task_1Args*)(task->args);
+  int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+
+
+  int32_t in = getIndexPoint(task, 0);
+  int32_t jn = getIndexPoint(task, 1);
+}
+
+void placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, LogicalPartition aPartition, int32_t gridX, int32_t gridY) {
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  RegionRequirement aReq = RegionRequirement(aPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(a));
   aReq.add_field(FID_VAL);
   task_1Args taskArgsRaw;
   taskArgsRaw.gridX = gridX;
@@ -102,24 +95,10 @@ LogicalPartition placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, in
   launcher.add_region_requirement(aReq);
   auto fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  return runtime->get_logical_partition(ctx, get_logical_region(a), aPartition);
 
 }
 
-void task_2(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion b = regions[0];
-
-  int32_t distFused = task->index_point[0];
-  task_2Args* args = (task_2Args*)(task->args);
-  int32_t gridX = args->gridX;
-  int32_t gridY = args->gridY;
-
-
-  int32_t in = getIndexPoint(task, 0);
-  int32_t jn = getIndexPoint(task, 1);
-}
-
-LogicalPartition placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, int32_t gridX, int32_t gridY) {
+std::vector<LogicalPartition> partitionForplaceLegionB(Context ctx, Runtime* runtime, LogicalRegion b, int32_t gridX, int32_t gridY) {
   int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
   int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
   auto b_index_space = get_index_space(b);
@@ -142,8 +121,31 @@ LogicalPartition placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, in
     bColoring[(*itr)] = bRect;
   }
   auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_COMPUTE_KIND);
-  LogicalPartition bLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
-  RegionRequirement bReq = RegionRequirement(bLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(b), bPartition));
+  return computePartitions;
+}
+
+void task_2(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion b = regions[0];
+
+  int32_t distFused = task->index_point[0];
+  task_2Args* args = (task_2Args*)(task->args);
+  int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+
+
+  int32_t in = getIndexPoint(task, 0);
+  int32_t jn = getIndexPoint(task, 1);
+}
+
+void placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, LogicalPartition bPartition, int32_t gridX, int32_t gridY) {
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  RegionRequirement bReq = RegionRequirement(bPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
   bReq.add_field(FID_VAL);
   task_2Args taskArgsRaw;
   taskArgsRaw.gridX = gridX;
@@ -153,24 +155,10 @@ LogicalPartition placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, in
   launcher.add_region_requirement(bReq);
   auto fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  return runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
 
 }
 
-void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion c = regions[0];
-
-  int32_t distFused = task->index_point[0];
-  task_3Args* args = (task_3Args*)(task->args);
-  int32_t gridX = args->gridX;
-  int32_t gridY = args->gridY;
-
-
-  int32_t in = getIndexPoint(task, 0);
-  int32_t jn = getIndexPoint(task, 1);
-}
-
-LogicalPartition placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, int32_t gridX, int32_t gridY) {
+std::vector<LogicalPartition> partitionForplaceLegionC(Context ctx, Runtime* runtime, LogicalRegion c, int32_t gridX, int32_t gridY) {
   int c1_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[0] + 1;
   int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
   auto c_index_space = get_index_space(c);
@@ -193,8 +181,31 @@ LogicalPartition placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, in
     cColoring[(*itr)] = cRect;
   }
   auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_COMPUTE_KIND);
-  LogicalPartition cLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(c), cPartition);
-  RegionRequirement cReq = RegionRequirement(cLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(c), cPartition));
+  return computePartitions;
+}
+
+void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion c = regions[0];
+
+  int32_t distFused = task->index_point[0];
+  task_3Args* args = (task_3Args*)(task->args);
+  int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+
+
+  int32_t in = getIndexPoint(task, 0);
+  int32_t jn = getIndexPoint(task, 1);
+}
+
+void placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, LogicalPartition cPartition, int32_t gridX, int32_t gridY) {
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  RegionRequirement cReq = RegionRequirement(cPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
   cReq.add_field(FID_VAL);
   task_3Args taskArgsRaw;
   taskArgsRaw.gridX = gridX;
@@ -204,8 +215,60 @@ LogicalPartition placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, in
   launcher.add_region_requirement(cReq);
   auto fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  return runtime->get_logical_partition(ctx, get_logical_region(c), cPartition);
 
+}
+
+std::vector<LogicalPartition> partitionForcomputeLegion(Context ctx, Runtime* runtime, LogicalRegion a, LogicalRegion b, LogicalRegion c, int32_t gridX, int32_t gridY) {
+  auto a_index_space = get_index_space(a);
+  int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
+  int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
+  auto b_index_space = get_index_space(b);
+  int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
+  auto c_index_space = get_index_space(c);
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  auto aDomain = runtime->get_index_space_domain(ctx, a_index_space);
+  auto bDomain = runtime->get_index_space_domain(ctx, b_index_space);
+  auto cDomain = runtime->get_index_space_domain(ctx, c_index_space);
+  DomainPointColoring aColoring = DomainPointColoring();
+  DomainPointColoring bColoring = DomainPointColoring();
+  DomainPointColoring cColoring = DomainPointColoring();
+  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
+    int32_t in = (*itr)[0];
+    int32_t jn = (*itr)[1];
+    Point<2> aStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> aEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + ((b1_dimension + (gridX - 1)) / gridX - 1)), aDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)), aDomain.hi()[1]));
+    Rect<2> aRect = Rect<2>(aStart, aEnd);
+    if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
+      aRect = aRect.make_empty();
+    }
+    aColoring[(*itr)] = aRect;
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (0 / gridX));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + ((b1_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[0]), TACO_MIN(((gridX - 1) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[1]));
+    Rect<2> bRect = Rect<2>(bStart, bEnd);
+    if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
+      bRect = bRect.make_empty();
+    }
+    bColoring[(*itr)] = bRect;
+    Point<2> cStart = Point<2>((0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> cEnd = Point<2>(TACO_MIN(((gridX - 1) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)), cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)), cDomain.hi()[1]));
+    Rect<2> cRect = Rect<2>(cStart, cEnd);
+    if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
+      cRect = cRect.make_empty();
+    }
+    cColoring[(*itr)] = cRect;
+  }
+  auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_ALIASED_COMPLETE_KIND);
+  auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_ALIASED_COMPLETE_KIND);
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(a), aPartition));
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(b), bPartition));
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(c), cPartition));
+  return computePartitions;
 }
 
 void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
@@ -213,12 +276,7 @@ void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   PhysicalRegion b = regions[1];
   PhysicalRegion c = regions[2];
 
-  task_4Args* args = (task_4Args*)(task->args);
-  int32_t gridX = args->gridX;
-  int32_t in = args->in;
-  int32_t jn = args->jn;
-  int32_t kos = args->kos;
-
+  int32_t iln = task->index_point[0];
   auto a_index_space = get_index_space(a);
   auto b_index_space = get_index_space(b);
   auto c_index_space = get_index_space(c);
@@ -255,22 +313,87 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   PhysicalRegion b = regions[1];
   PhysicalRegion c = regions[2];
 
-  int32_t distFused = task->index_point[0];
   task_5Args* args = (task_5Args*)(task->args);
-  int32_t c1_dimension = args->c1_dimension;
+  int32_t b1_dimension = args->b1_dimension;
+  int32_t b2_dimension = args->b2_dimension;
+  int32_t c2_dimension = args->c2_dimension;
   int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+  int32_t in = args->in;
+  int32_t jn = args->jn;
+  int32_t kos = args->kos;
 
   auto a_index_space = get_index_space(a);
   auto b_index_space = get_index_space(b);
   auto c_index_space = get_index_space(c);
 
+  Point<1> lowerBound = Point<1>(0);
+  Point<1> upperBound = Point<1>(1);
+  auto ilnIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
+  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(ilnIndexSpace));
+  auto aDomain = runtime->get_index_space_domain(ctx, a_index_space);
+  auto bDomain = runtime->get_index_space_domain(ctx, b_index_space);
+  auto cDomain = runtime->get_index_space_domain(ctx, c_index_space);
+  DomainPointColoring aColoring = DomainPointColoring();
+  DomainPointColoring bColoring = DomainPointColoring();
+  DomainPointColoring cColoring = DomainPointColoring();
+  for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
+    int32_t iln = (*itr)[0];
+    Point<2> aStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> aEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))), aDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)), aDomain.hi()[1]));
+    Rect<2> aRect = Rect<2>(aStart, aEnd);
+    if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
+      aRect = aRect.make_empty();
+    }
+    aColoring[(*itr)] = aRect;
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))), bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[1]));
+    Rect<2> bRect = Rect<2>(bStart, bEnd);
+    if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
+      bRect = bRect.make_empty();
+    }
+    bColoring[(*itr)] = bRect;
+  }
+  auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  LogicalPartition aLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(a), aPartition);
+  RegionRequirement aReq = RegionRequirement(aLogicalPartition, 0, READ_WRITE, EXCLUSIVE, get_logical_region(a));
+  aReq.add_field(FID_VAL);
+  LogicalPartition bLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
+  RegionRequirement bReq = RegionRequirement(bLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
+  bReq.add_field(FID_VAL);
+  RegionRequirement cReq = RegionRequirement(get_logical_region(c), READ_ONLY, EXCLUSIVE, get_logical_region(c));
+  cReq.add_field(FID_VAL);
+  task_4Args taskArgsRaw;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_4Args));
+  IndexLauncher launcher = IndexLauncher(taskID(4), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(aReq);
+  launcher.add_region_requirement(bReq);
+  launcher.add_region_requirement(cReq);
+  launcher.tag |= TACOMapper::UNTRACK_VALID_REGIONS;
+  launcher.tag |= Mapping::DefaultMapper::SAME_ADDRESS_SPACE;
+  runtime->execute_index_space(ctx, launcher);
+
+}
+
+void task_6(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion a = regions[0];
+  PhysicalRegion b = regions[1];
+  PhysicalRegion c = regions[2];
+
+  int32_t distFused = task->index_point[0];
+  task_6Args* args = (task_6Args*)(task->args);
+  int32_t b1_dimension = args->b1_dimension;
+  int32_t b2_dimension = args->b2_dimension;
+  int32_t c2_dimension = args->c2_dimension;
+  int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+
+  auto b_index_space = get_index_space(b);
+  auto c_index_space = get_index_space(c);
+
   int32_t in = getIndexPoint(task, 0);
   int32_t jn = getIndexPoint(task, 1);
-  auto aPartitionBounds = runtime->get_index_space_domain(ctx, a_index_space);
-  int64_t aPartitionBounds0lo = aPartitionBounds.lo()[0];
-  int64_t aPartitionBounds0hi = aPartitionBounds.hi()[0];
-  int64_t aPartitionBounds1lo = aPartitionBounds.lo()[1];
-  int64_t aPartitionBounds1hi = aPartitionBounds.hi()[1];
   Point<1> lowerBound = Point<1>(0);
   Point<1> upperBound = Point<1>((gridX - 1));
   auto kosIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
@@ -281,15 +404,15 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   DomainPointColoring cColoring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t kos = (*itr)[0];
-    Point<2> bStart = Point<2>(aPartitionBounds0lo, (((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + 0 / gridX));
-    Point<2> bEnd = Point<2>(TACO_MIN(((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) - 1) + aPartitionBounds0lo), bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[1]));
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + ((b1_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[1]));
     Rect<2> bRect = Rect<2>(bStart, bEnd);
     if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
       bRect = bRect.make_empty();
     }
     bColoring[(*itr)] = bRect;
-    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + 0 / gridX), aPartitionBounds1lo);
-    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)), cDomain.hi()[0]), TACO_MIN(((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) - 1) + aPartitionBounds1lo), cDomain.hi()[1]));
+    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)), cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)), cDomain.hi()[1]));
     Rect<2> cRect = Rect<2>(cStart, cEnd);
     if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
       cRect = cRect.make_empty();
@@ -302,19 +425,26 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
     int32_t kos = (*itr);
     RegionRequirement aReq = RegionRequirement(get_logical_region(a), READ_WRITE, EXCLUSIVE, get_logical_region(a));
     aReq.add_field(FID_VAL);
+    aReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
     auto bsubReg = runtime->get_logical_subregion_by_color(ctx, runtime->get_logical_partition(ctx, get_logical_region(b), bPartition), kos);
     RegionRequirement bReq = RegionRequirement(bsubReg, READ_ONLY, EXCLUSIVE, get_logical_region(b));
     bReq.add_field(FID_VAL);
+    bReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
     auto csubReg = runtime->get_logical_subregion_by_color(ctx, runtime->get_logical_partition(ctx, get_logical_region(c), cPartition), kos);
     RegionRequirement cReq = RegionRequirement(csubReg, READ_ONLY, EXCLUSIVE, get_logical_region(c));
     cReq.add_field(FID_VAL);
-    task_4Args taskArgsRaw;
+    cReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
+    task_5Args taskArgsRaw;
+    taskArgsRaw.b1_dimension = b1_dimension;
+    taskArgsRaw.b2_dimension = b2_dimension;
+    taskArgsRaw.c2_dimension = c2_dimension;
     taskArgsRaw.gridX = gridX;
+    taskArgsRaw.gridY = gridY;
     taskArgsRaw.in = in;
     taskArgsRaw.jn = jn;
     taskArgsRaw.kos = kos;
-    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_4Args));
-    TaskLauncher launcher = TaskLauncher(taskID(4), taskArgs);
+    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_5Args));
+    TaskLauncher launcher = TaskLauncher(taskID(5), taskArgs);
     launcher.add_region_requirement(aReq);
     launcher.add_region_requirement(bReq);
     launcher.add_region_requirement(cReq);
@@ -323,56 +453,32 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
 
 }
 
-void computeLegion(Context ctx, Runtime* runtime, LogicalRegion a, LogicalRegion b, LogicalRegion c, LogicalPartition aPartition, int32_t gridX) {
-  auto b_index_space = get_index_space(b);
-  int c1_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[0] + 1;
-  auto c_index_space = get_index_space(c);
+void computeLegion(Context ctx, Runtime* runtime, LogicalRegion a, LogicalRegion b, LogicalRegion c, LogicalPartition aPartition, LogicalPartition bPartition, LogicalPartition cPartition, int32_t gridX, int32_t gridY) {
+  int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
+  int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
+  int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
 
-  DomainT<2> domain = runtime->get_index_partition_color_space(ctx, get_index_partition(aPartition));
-  auto bDomain = runtime->get_index_space_domain(ctx, b_index_space);
-  auto cDomain = runtime->get_index_space_domain(ctx, c_index_space);
-  DomainPointColoring bColoring = DomainPointColoring();
-  DomainPointColoring cColoring = DomainPointColoring();
-  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
-    DomainPoint domPoint = (*itr);
-    auto aPartitionBounds = runtime->get_index_space_domain(runtime->get_logical_subregion_by_color(ctx, aPartition, domPoint).get_index_space());
-    int64_t aPartitionBounds0lo = aPartitionBounds.lo()[0];
-    int64_t aPartitionBounds0hi = aPartitionBounds.hi()[0];
-    int64_t aPartitionBounds1lo = aPartitionBounds.lo()[1];
-    int64_t aPartitionBounds1hi = aPartitionBounds.hi()[1];
-    Point<2> bStart = Point<2>(aPartitionBounds0lo, (0 / gridX));
-    Point<2> bEnd = Point<2>(TACO_MIN(((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) - 1) + aPartitionBounds0lo), bDomain.hi()[0]), TACO_MIN(((gridX - 1) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)), bDomain.hi()[1]));
-    Rect<2> bRect = Rect<2>(bStart, bEnd);
-    if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
-      bRect = bRect.make_empty();
-    }
-    bColoring[(*itr)] = bRect;
-    Point<2> cStart = Point<2>((0 / gridX), aPartitionBounds1lo);
-    Point<2> cEnd = Point<2>(TACO_MIN(((gridX - 1) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)), cDomain.hi()[0]), TACO_MIN(((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) - 1) + aPartitionBounds1lo), cDomain.hi()[1]));
-    Rect<2> cRect = Rect<2>(cStart, cEnd);
-    if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
-      cRect = cRect.make_empty();
-    }
-    cColoring[(*itr)] = cRect;
-  }
-  auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_ALIASED_COMPLETE_KIND);
-  auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_ALIASED_COMPLETE_KIND);
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
   RegionRequirement aReq = RegionRequirement(aPartition, 0, READ_WRITE, EXCLUSIVE, get_logical_region(a));
   aReq.add_field(FID_VAL);
   aReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  LogicalPartition bLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
-  RegionRequirement bReq = RegionRequirement(bLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
+  RegionRequirement bReq = RegionRequirement(bPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
   bReq.add_field(FID_VAL);
   bReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  LogicalPartition cLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(c), cPartition);
-  RegionRequirement cReq = RegionRequirement(cLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
+  RegionRequirement cReq = RegionRequirement(cPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
   cReq.add_field(FID_VAL);
   cReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  task_5Args taskArgsRaw;
-  taskArgsRaw.c1_dimension = c1_dimension;
+  task_6Args taskArgsRaw;
+  taskArgsRaw.b1_dimension = b1_dimension;
+  taskArgsRaw.b2_dimension = b2_dimension;
+  taskArgsRaw.c2_dimension = c2_dimension;
   taskArgsRaw.gridX = gridX;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_5Args));
-  IndexLauncher launcher = IndexLauncher(taskID(5), domain, taskArgs, ArgumentMap());
+  taskArgsRaw.gridY = gridY;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_6Args));
+  IndexLauncher launcher = IndexLauncher(taskID(6), domain, taskArgs, ArgumentMap());
   launcher.add_region_requirement(aReq);
   launcher.add_region_requirement(bReq);
   launcher.add_region_requirement(cReq);
@@ -410,5 +516,11 @@ void registerTacoTasks() {
     registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
     registrar.set_inner();
     Runtime::preregister_task_variant<task_5>(registrar, "task_5");
+  }
+  {
+    TaskVariantRegistrar registrar(taskID(6), "task_6");
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    registrar.set_inner();
+    Runtime::preregister_task_variant<task_6>(registrar, "task_6");
   }
 }

--- a/legion/cannonMM/taco-generated.cu
+++ b/legion/cannonMM/taco-generated.cu
@@ -1,5 +1,6 @@
 #include "cublas_v2.h"
 #include "cudalibs.h"
+#include "leaf_kernels.cuh"
 #include "taco_legion_header.h"
 #include "taco_mapper.h"
 #define TACO_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))
@@ -8,61 +9,61 @@ typedef FieldAccessor<READ_ONLY,double,2,coord_t,Realm::AffineAccessor<double,2,
 typedef FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t>> AccessorRWdouble2;
 
 struct task_1Args {
-  int32_t gridX;
-  int32_t gridY;
 };
 struct task_2Args {
+  int32_t a1_dimension;
+  int32_t a2_dimension;
   int32_t gridX;
   int32_t gridY;
 };
 struct task_3Args {
+};
+struct task_4Args {
+  int32_t b1_dimension;
+  int32_t b2_dimension;
   int32_t gridX;
   int32_t gridY;
 };
-struct task_4Args {
-  int32_t kios;
-};
 struct task_5Args {
-  int64_t aPartitionBounds0hi;
-  int64_t aPartitionBounds0lo;
-  int64_t aPartitionBounds1hi;
-  int64_t aPartitionBounds1lo;
-  int32_t c1_dimension;
-  int32_t gridX;
-  int32_t in;
-  int32_t jn;
-  int32_t kos;
 };
 struct task_6Args {
-  int64_t aPartitionBounds0hi;
-  int64_t aPartitionBounds0lo;
-  int64_t aPartitionBounds1hi;
-  int64_t aPartitionBounds1lo;
   int32_t c1_dimension;
+  int32_t c2_dimension;
   int32_t gridX;
+  int32_t gridY;
+};
+struct task_7Args {
+  int32_t kios;
+};
+struct task_8Args {
+  int32_t b1_dimension;
+  int32_t b2_dimension;
+  int32_t c2_dimension;
+  int32_t gridX;
+  int32_t gridY;
   int32_t in;
   int32_t jn;
   int32_t kos;
 };
-struct task_7Args {
-  int32_t c1_dimension;
+struct task_9Args {
+  int32_t b1_dimension;
+  int32_t b2_dimension;
+  int32_t c2_dimension;
   int32_t gridX;
+  int32_t gridY;
+  int32_t in;
+  int32_t jn;
+  int32_t kos;
+};
+struct task_10Args {
+  int32_t b1_dimension;
+  int32_t b2_dimension;
+  int32_t c2_dimension;
+  int32_t gridX;
+  int32_t gridY;
 };
 
-void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion a = regions[0];
-
-  int32_t distFused = task->index_point[0];
-  task_1Args* args = (task_1Args*)(task->args);
-  int32_t gridX = args->gridX;
-  int32_t gridY = args->gridY;
-
-
-  int32_t in = getIndexPoint(task, 0);
-  int32_t jn = getIndexPoint(task, 1);
-}
-
-LogicalPartition placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, int32_t gridX, int32_t gridY) {
+std::vector<LogicalPartition> partitionForplaceLegionA(Context ctx, Runtime* runtime, LogicalRegion a, int32_t gridX, int32_t gridY) {
   int a1_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[0] + 1;
   int a2_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[1] + 1;
   auto a_index_space = get_index_space(a);
@@ -85,35 +86,89 @@ LogicalPartition placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, in
     aColoring[(*itr)] = aRect;
   }
   auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_COMPUTE_KIND);
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(a), aPartition));
+  return computePartitions;
+}
+
+void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion a = regions[0];
+
+  int32_t distFused1 = task->index_point[0];
+
+  int32_t iln = getIndexPoint(task, 0);
+  int32_t jln = getIndexPoint(task, 1);
+}
+
+void task_2(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion a = regions[0];
+
+  int32_t distFused = task->index_point[0];
+  task_2Args* args = (task_2Args*)(task->args);
+  int32_t a1_dimension = args->a1_dimension;
+  int32_t a2_dimension = args->a2_dimension;
+  int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+
+  auto a_index_space = get_index_space(a);
+
+  int32_t in = getIndexPoint(task, 0);
+  int32_t jn = getIndexPoint(task, 1);
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>(1, 1);
+  auto distFused1IndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFused1IndexSpace));
+  auto aDomain = runtime->get_index_space_domain(ctx, a_index_space);
+  DomainPointColoring aColoring = DomainPointColoring();
+  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
+    int32_t iln = (*itr)[0];
+    int32_t jln = (*itr)[1];
+    Point<2> aStart = Point<2>((in * ((a1_dimension + (gridX - 1)) / gridX) + (iln * ((((a1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jn * ((a2_dimension + (gridY - 1)) / gridY) + (jln * ((((a2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (0 / gridY) / 2)));
+    Point<2> aEnd = Point<2>(TACO_MIN((in * ((a1_dimension + (gridX - 1)) / gridX) + (iln * ((((a1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((a1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),aDomain.hi()[0]), TACO_MIN((jn * ((a2_dimension + (gridY - 1)) / gridY) + (jln * ((((a2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (((a2_dimension + (gridY - 1)) / gridY + 1) / 2 - 1))),aDomain.hi()[1]));
+    Rect<2> aRect = Rect<2>(aStart, aEnd);
+    if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
+      aRect = aRect.make_empty();
+    }
+    aColoring[(*itr)] = aRect;
+  }
+  auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_COMPUTE_KIND);
   LogicalPartition aLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(a), aPartition);
   RegionRequirement aReq = RegionRequirement(aLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(a));
   aReq.add_field(FID_VAL);
   task_1Args taskArgsRaw;
-  taskArgsRaw.gridX = gridX;
-  taskArgsRaw.gridY = gridY;
   TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_1Args));
   IndexLauncher launcher = IndexLauncher(taskID(1), domain, taskArgs, ArgumentMap());
   launcher.add_region_requirement(aReq);
+  launcher.tag = launcher.tag | Mapping::DefaultMapper::SAME_ADDRESS_SPACE;
+  runtime->execute_index_space(ctx, launcher);
+
+}
+
+void placeLegionA(Context ctx, Runtime* runtime, LogicalRegion a, LogicalPartition aPartition, int32_t gridX, int32_t gridY) {
+  int a1_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[0] + 1;
+  int a2_dimension = runtime->get_index_space_domain(get_index_space(a)).hi()[1] + 1;
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  RegionRequirement aReq = RegionRequirement(aPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(a));
+  aReq.add_field(FID_VAL);
+  aReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
+  task_2Args taskArgsRaw;
+  taskArgsRaw.a1_dimension = a1_dimension;
+  taskArgsRaw.a2_dimension = a2_dimension;
+  taskArgsRaw.gridX = gridX;
+  taskArgsRaw.gridY = gridY;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_2Args));
+  IndexLauncher launcher = IndexLauncher(taskID(2), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(aReq);
   auto fm = runtime->execute_index_space(ctx, launcher);
   fm.wait_all_results();
-  return runtime->get_logical_partition(ctx, get_logical_region(a), aPartition);
 
 }
 
-void task_2(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion b = regions[0];
-
-  int32_t distFused = task->index_point[0];
-  task_2Args* args = (task_2Args*)(task->args);
-  int32_t gridX = args->gridX;
-  int32_t gridY = args->gridY;
-
-
-  int32_t in = getIndexPoint(task, 0);
-  int32_t jn = getIndexPoint(task, 1);
-}
-
-LogicalPartition placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, int32_t gridX, int32_t gridY) {
+std::vector<LogicalPartition> partitionForplaceLegionB(Context ctx, Runtime* runtime, LogicalRegion b, int32_t gridX, int32_t gridY) {
   int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
   int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
   auto b_index_space = get_index_space(b);
@@ -136,35 +191,89 @@ LogicalPartition placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, in
     bColoring[(*itr)] = bRect;
   }
   auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_COMPUTE_KIND);
-  LogicalPartition bLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
-  RegionRequirement bReq = RegionRequirement(bLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
-  bReq.add_field(FID_VAL);
-  task_2Args taskArgsRaw;
-  taskArgsRaw.gridX = gridX;
-  taskArgsRaw.gridY = gridY;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_2Args));
-  IndexLauncher launcher = IndexLauncher(taskID(2), domain, taskArgs, ArgumentMap());
-  launcher.add_region_requirement(bReq);
-  auto fm = runtime->execute_index_space(ctx, launcher);
-  fm.wait_all_results();
-  return runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
-
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(b), bPartition));
+  return computePartitions;
 }
 
 void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion c = regions[0];
+  PhysicalRegion b = regions[0];
+
+  int32_t distFused1 = task->index_point[0];
+
+  int32_t iln = getIndexPoint(task, 0);
+  int32_t jln = getIndexPoint(task, 1);
+}
+
+void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion b = regions[0];
 
   int32_t distFused = task->index_point[0];
-  task_3Args* args = (task_3Args*)(task->args);
+  task_4Args* args = (task_4Args*)(task->args);
+  int32_t b1_dimension = args->b1_dimension;
+  int32_t b2_dimension = args->b2_dimension;
   int32_t gridX = args->gridX;
   int32_t gridY = args->gridY;
 
+  auto b_index_space = get_index_space(b);
 
   int32_t in = getIndexPoint(task, 0);
   int32_t jn = getIndexPoint(task, 1);
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>(1, 1);
+  auto distFused1IndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFused1IndexSpace));
+  auto bDomain = runtime->get_index_space_domain(ctx, b_index_space);
+  DomainPointColoring bColoring = DomainPointColoring();
+  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
+    int32_t iln = (*itr)[0];
+    int32_t jln = (*itr)[1];
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jn * ((b2_dimension + (gridY - 1)) / gridY) + (jln * ((((b2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (0 / gridY) / 2)));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),bDomain.hi()[0]), TACO_MIN((jn * ((b2_dimension + (gridY - 1)) / gridY) + (jln * ((((b2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (((b2_dimension + (gridY - 1)) / gridY + 1) / 2 - 1))),bDomain.hi()[1]));
+    Rect<2> bRect = Rect<2>(bStart, bEnd);
+    if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
+      bRect = bRect.make_empty();
+    }
+    bColoring[(*itr)] = bRect;
+  }
+  auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_COMPUTE_KIND);
+  LogicalPartition bLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
+  RegionRequirement bReq = RegionRequirement(bLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
+  bReq.add_field(FID_VAL);
+  task_3Args taskArgsRaw;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_3Args));
+  IndexLauncher launcher = IndexLauncher(taskID(3), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(bReq);
+  launcher.tag = launcher.tag | Mapping::DefaultMapper::SAME_ADDRESS_SPACE;
+  runtime->execute_index_space(ctx, launcher);
+
 }
 
-LogicalPartition placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, int32_t gridX, int32_t gridY) {
+void placeLegionB(Context ctx, Runtime* runtime, LogicalRegion b, LogicalPartition bPartition, int32_t gridX, int32_t gridY) {
+  int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
+  int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  RegionRequirement bReq = RegionRequirement(bPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
+  bReq.add_field(FID_VAL);
+  bReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
+  task_4Args taskArgsRaw;
+  taskArgsRaw.b1_dimension = b1_dimension;
+  taskArgsRaw.b2_dimension = b2_dimension;
+  taskArgsRaw.gridX = gridX;
+  taskArgsRaw.gridY = gridY;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_4Args));
+  IndexLauncher launcher = IndexLauncher(taskID(4), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(bReq);
+  auto fm = runtime->execute_index_space(ctx, launcher);
+  fm.wait_all_results();
+
+}
+
+std::vector<LogicalPartition> partitionForplaceLegionC(Context ctx, Runtime* runtime, LogicalRegion c, int32_t gridX, int32_t gridY) {
   int c1_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[0] + 1;
   int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
   auto c_index_space = get_index_space(c);
@@ -187,27 +296,147 @@ LogicalPartition placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, in
     cColoring[(*itr)] = cRect;
   }
   auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_COMPUTE_KIND);
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(c), cPartition));
+  return computePartitions;
+}
+
+void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion c = regions[0];
+
+  int32_t distFused1 = task->index_point[0];
+
+  int32_t iln = getIndexPoint(task, 0);
+  int32_t jln = getIndexPoint(task, 1);
+}
+
+void task_6(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion c = regions[0];
+
+  int32_t distFused = task->index_point[0];
+  task_6Args* args = (task_6Args*)(task->args);
+  int32_t c1_dimension = args->c1_dimension;
+  int32_t c2_dimension = args->c2_dimension;
+  int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
+
+  auto c_index_space = get_index_space(c);
+
+  int32_t in = getIndexPoint(task, 0);
+  int32_t jn = getIndexPoint(task, 1);
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>(1, 1);
+  auto distFused1IndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFused1IndexSpace));
+  auto cDomain = runtime->get_index_space_domain(ctx, c_index_space);
+  DomainPointColoring cColoring = DomainPointColoring();
+  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
+    int32_t iln = (*itr)[0];
+    int32_t jln = (*itr)[1];
+    Point<2> cStart = Point<2>((in * ((c1_dimension + (gridX - 1)) / gridX) + (iln * ((((c1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (0 / gridY) / 2)));
+    Point<2> cEnd = Point<2>(TACO_MIN((in * ((c1_dimension + (gridX - 1)) / gridX) + (iln * ((((c1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((c1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (((c2_dimension + (gridY - 1)) / gridY + 1) / 2 - 1))),cDomain.hi()[1]));
+    Rect<2> cRect = Rect<2>(cStart, cEnd);
+    if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
+      cRect = cRect.make_empty();
+    }
+    cColoring[(*itr)] = cRect;
+  }
+  auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_COMPUTE_KIND);
   LogicalPartition cLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(c), cPartition);
   RegionRequirement cReq = RegionRequirement(cLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
   cReq.add_field(FID_VAL);
-  task_3Args taskArgsRaw;
-  taskArgsRaw.gridX = gridX;
-  taskArgsRaw.gridY = gridY;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_3Args));
-  IndexLauncher launcher = IndexLauncher(taskID(3), domain, taskArgs, ArgumentMap());
+  task_5Args taskArgsRaw;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_5Args));
+  IndexLauncher launcher = IndexLauncher(taskID(5), domain, taskArgs, ArgumentMap());
   launcher.add_region_requirement(cReq);
-  auto fm = runtime->execute_index_space(ctx, launcher);
-  fm.wait_all_results();
-  return runtime->get_logical_partition(ctx, get_logical_region(c), cPartition);
+  launcher.tag = launcher.tag | Mapping::DefaultMapper::SAME_ADDRESS_SPACE;
+  runtime->execute_index_space(ctx, launcher);
 
 }
 
-void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+void placeLegionC(Context ctx, Runtime* runtime, LogicalRegion c, LogicalPartition cPartition, int32_t gridX, int32_t gridY) {
+  int c1_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[0] + 1;
+  int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  RegionRequirement cReq = RegionRequirement(cPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
+  cReq.add_field(FID_VAL);
+  cReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
+  task_6Args taskArgsRaw;
+  taskArgsRaw.c1_dimension = c1_dimension;
+  taskArgsRaw.c2_dimension = c2_dimension;
+  taskArgsRaw.gridX = gridX;
+  taskArgsRaw.gridY = gridY;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_6Args));
+  IndexLauncher launcher = IndexLauncher(taskID(6), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(cReq);
+  auto fm = runtime->execute_index_space(ctx, launcher);
+  fm.wait_all_results();
+
+}
+
+std::vector<LogicalPartition> partitionForcomputeLegion(Context ctx, Runtime* runtime, LogicalRegion a, LogicalRegion b, LogicalRegion c, int32_t gridX, int32_t gridY) {
+  auto a_index_space = get_index_space(a);
+  int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
+  int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
+  auto b_index_space = get_index_space(b);
+  int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
+  auto c_index_space = get_index_space(c);
+
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
+  auto aDomain = runtime->get_index_space_domain(ctx, a_index_space);
+  auto bDomain = runtime->get_index_space_domain(ctx, b_index_space);
+  auto cDomain = runtime->get_index_space_domain(ctx, c_index_space);
+  DomainPointColoring aColoring = DomainPointColoring();
+  DomainPointColoring bColoring = DomainPointColoring();
+  DomainPointColoring cColoring = DomainPointColoring();
+  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
+    int32_t in = (*itr)[0];
+    int32_t jn = (*itr)[1];
+    Point<2> aStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> aEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + ((b1_dimension + (gridX - 1)) / gridX - 1)),aDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)),aDomain.hi()[1]));
+    Rect<2> aRect = Rect<2>(aStart, aEnd);
+    if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
+      aRect = aRect.make_empty();
+    }
+    aColoring[(*itr)] = aRect;
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (0 / gridX));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + ((b1_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[0]), TACO_MIN(((gridX - 1) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[1]));
+    Rect<2> bRect = Rect<2>(bStart, bEnd);
+    if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
+      bRect = bRect.make_empty();
+    }
+    bColoring[(*itr)] = bRect;
+    Point<2> cStart = Point<2>((0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> cEnd = Point<2>(TACO_MIN(((gridX - 1) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)),cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)),cDomain.hi()[1]));
+    Rect<2> cRect = Rect<2>(cStart, cEnd);
+    if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
+      cRect = cRect.make_empty();
+    }
+    cColoring[(*itr)] = cRect;
+  }
+  auto aPartition = runtime->create_index_partition(ctx, a_index_space, domain, aColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_ALIASED_COMPLETE_KIND);
+  auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_ALIASED_COMPLETE_KIND);
+  std::vector<LogicalPartition> computePartitions = std::vector<LogicalPartition>();
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(a), aPartition));
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(b), bPartition));
+  computePartitions.push_back(runtime->get_logical_partition(ctx, get_logical_region(c), cPartition));
+  return computePartitions;
+}
+
+void task_7(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
   PhysicalRegion a = regions[0];
   PhysicalRegion b = regions[1];
   PhysicalRegion c = regions[2];
 
-  task_4Args* args = (task_4Args*)(task->args);
+  task_7Args* args = (task_7Args*)(task->args);
   int32_t kios = args->kios;
 
   auto a_index_space = get_index_space(a);
@@ -246,19 +475,18 @@ void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   ));
 }
 
-void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+void task_8(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
   PhysicalRegion a = regions[0];
   PhysicalRegion b = regions[1];
   PhysicalRegion c = regions[2];
 
   int32_t distFused1 = task->index_point[0];
-  task_5Args* args = (task_5Args*)(task->args);
-  int64_t aPartitionBounds0hi = args->aPartitionBounds0hi;
-  int64_t aPartitionBounds0lo = args->aPartitionBounds0lo;
-  int64_t aPartitionBounds1hi = args->aPartitionBounds1hi;
-  int64_t aPartitionBounds1lo = args->aPartitionBounds1lo;
-  int32_t c1_dimension = args->c1_dimension;
+  task_8Args* args = (task_8Args*)(task->args);
+  int32_t b1_dimension = args->b1_dimension;
+  int32_t b2_dimension = args->b2_dimension;
+  int32_t c2_dimension = args->c2_dimension;
   int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
   int32_t in = args->in;
   int32_t jn = args->jn;
   int32_t kos = args->kos;
@@ -278,15 +506,15 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   DomainPointColoring cColoring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t kios = (*itr)[0];
-    Point<2> bStart = Point<2>((iln * ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2) + aPartitionBounds0lo), (((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((c1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)));
-    Point<2> bEnd = Point<2>(TACO_MIN(((iln * ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2) + ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2 - 1)) + aPartitionBounds0lo),bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((c1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((c1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),bDomain.hi()[1]));
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((b2_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((b2_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b2_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),bDomain.hi()[1]));
     Rect<2> bRect = Rect<2>(bStart, bEnd);
     if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
       bRect = bRect.make_empty();
     }
     bColoring[(*itr)] = bRect;
-    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((c1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jln * ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2) + aPartitionBounds1lo));
-    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((c1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((c1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),cDomain.hi()[0]), TACO_MIN(((jln * ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2) + ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2 - 1)) + aPartitionBounds1lo),cDomain.hi()[1]));
+    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((b2_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (0 / gridY) / 2)));
+    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + (((jln + (iln + kios)) % 2) * ((((b2_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b2_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (((c2_dimension + (gridY - 1)) / gridY + 1) / 2 - 1))),cDomain.hi()[1]));
     Rect<2> cRect = Rect<2>(cStart, cEnd);
     if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
       cRect = cRect.make_empty();
@@ -305,30 +533,30 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
     auto csubReg = runtime->get_logical_subregion_by_color(ctx, runtime->get_logical_partition(ctx, get_logical_region(c), cPartition), kios);
     RegionRequirement cReq = RegionRequirement(csubReg, READ_ONLY, EXCLUSIVE, get_logical_region(c));
     cReq.add_field(FID_VAL);
-    task_4Args taskArgsRaw;
+    task_7Args taskArgsRaw;
     taskArgsRaw.kios = kios;
-    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_4Args));
-    TaskLauncher launcher = TaskLauncher(taskID(4), taskArgs);
+    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_7Args));
+    TaskLauncher launcher = TaskLauncher(taskID(7), taskArgs);
     launcher.add_region_requirement(aReq);
     launcher.add_region_requirement(bReq);
     launcher.add_region_requirement(cReq);
+    launcher.tag = launcher.tag | TACOMapper::UNTRACK_VALID_REGIONS;
     runtime->execute_task(ctx, launcher);
   }
 
 }
 
-void task_6(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+void task_9(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
   PhysicalRegion a = regions[0];
   PhysicalRegion b = regions[1];
   PhysicalRegion c = regions[2];
 
-  task_6Args* args = (task_6Args*)(task->args);
-  int64_t aPartitionBounds0hi = args->aPartitionBounds0hi;
-  int64_t aPartitionBounds0lo = args->aPartitionBounds0lo;
-  int64_t aPartitionBounds1hi = args->aPartitionBounds1hi;
-  int64_t aPartitionBounds1lo = args->aPartitionBounds1lo;
-  int32_t c1_dimension = args->c1_dimension;
+  task_9Args* args = (task_9Args*)(task->args);
+  int32_t b1_dimension = args->b1_dimension;
+  int32_t b2_dimension = args->b2_dimension;
+  int32_t c2_dimension = args->c2_dimension;
   int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
   int32_t in = args->in;
   int32_t jn = args->jn;
   int32_t kos = args->kos;
@@ -350,22 +578,22 @@ void task_6(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
     int32_t iln = (*itr)[0];
     int32_t jln = (*itr)[1];
-    Point<2> bStart = Point<2>((iln * ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2) + aPartitionBounds0lo), (((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + 0 / gridX));
-    Point<2> bEnd = Point<2>(TACO_MIN(((iln * ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2) + ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2 - 1)) + aPartitionBounds0lo),bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[1]));
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[1]));
     Rect<2> bRect = Rect<2>(bStart, bEnd);
     if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
       bRect = bRect.make_empty();
     }
     bColoring[(*itr)] = bRect;
-    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jln * ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2) + aPartitionBounds1lo));
-    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)),cDomain.hi()[0]), TACO_MIN(((jln * ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2) + ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2 - 1)) + aPartitionBounds1lo),cDomain.hi()[1]));
+    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (0 / gridY) / 2)));
+    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)),cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (((c2_dimension + (gridY - 1)) / gridY + 1) / 2 - 1))),cDomain.hi()[1]));
     Rect<2> cRect = Rect<2>(cStart, cEnd);
     if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
       cRect = cRect.make_empty();
     }
     cColoring[(*itr)] = cRect;
-    Point<2> aStart = Point<2>((iln * ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2) + aPartitionBounds0lo), (jln * ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2) + aPartitionBounds1lo));
-    Point<2> aEnd = Point<2>(TACO_MIN(((iln * ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2) + ((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) + 1) / 2 - 1)) + aPartitionBounds0lo),aDomain.hi()[0]), TACO_MIN(((jln * ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2) + ((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) + 1) / 2 - 1)) + aPartitionBounds1lo),aDomain.hi()[1]));
+    Point<2> aStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (0 / gridX) / 2)), (jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (0 / gridY) / 2)));
+    Point<2> aEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + (iln * ((((b1_dimension + (gridX - 1)) / gridX - 0 / gridX) + 1) / 2) + (((b1_dimension + (gridX - 1)) / gridX + 1) / 2 - 1))),aDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + (jln * ((((c2_dimension + (gridY - 1)) / gridY - 0 / gridY) + 1) / 2) + (((c2_dimension + (gridY - 1)) / gridY + 1) / 2 - 1))),aDomain.hi()[1]));
     Rect<2> aRect = Rect<2>(aStart, aEnd);
     if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
       aRect = aRect.make_empty();
@@ -387,18 +615,17 @@ void task_6(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   RegionRequirement cReq = RegionRequirement(cLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
   cReq.add_field(FID_VAL);
   cReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  task_5Args taskArgsRaw;
-  taskArgsRaw.aPartitionBounds0hi = aPartitionBounds0hi;
-  taskArgsRaw.aPartitionBounds0lo = aPartitionBounds0lo;
-  taskArgsRaw.aPartitionBounds1hi = aPartitionBounds1hi;
-  taskArgsRaw.aPartitionBounds1lo = aPartitionBounds1lo;
-  taskArgsRaw.c1_dimension = c1_dimension;
+  task_8Args taskArgsRaw;
+  taskArgsRaw.b1_dimension = b1_dimension;
+  taskArgsRaw.b2_dimension = b2_dimension;
+  taskArgsRaw.c2_dimension = c2_dimension;
   taskArgsRaw.gridX = gridX;
+  taskArgsRaw.gridY = gridY;
   taskArgsRaw.in = in;
   taskArgsRaw.jn = jn;
   taskArgsRaw.kos = kos;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_5Args));
-  IndexLauncher launcher = IndexLauncher(taskID(5), domain, taskArgs, ArgumentMap());
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_8Args));
+  IndexLauncher launcher = IndexLauncher(taskID(8), domain, taskArgs, ArgumentMap());
   launcher.add_region_requirement(aReq);
   launcher.add_region_requirement(bReq);
   launcher.add_region_requirement(cReq);
@@ -407,27 +634,24 @@ void task_6(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
 
 }
 
-void task_7(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+void task_10(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
   PhysicalRegion a = regions[0];
   PhysicalRegion b = regions[1];
   PhysicalRegion c = regions[2];
 
   int32_t distFused = task->index_point[0];
-  task_7Args* args = (task_7Args*)(task->args);
-  int32_t c1_dimension = args->c1_dimension;
+  task_10Args* args = (task_10Args*)(task->args);
+  int32_t b1_dimension = args->b1_dimension;
+  int32_t b2_dimension = args->b2_dimension;
+  int32_t c2_dimension = args->c2_dimension;
   int32_t gridX = args->gridX;
+  int32_t gridY = args->gridY;
 
-  auto a_index_space = get_index_space(a);
   auto b_index_space = get_index_space(b);
   auto c_index_space = get_index_space(c);
 
   int32_t in = getIndexPoint(task, 0);
   int32_t jn = getIndexPoint(task, 1);
-  auto aPartitionBounds = runtime->get_index_space_domain(ctx, a_index_space);
-  int64_t aPartitionBounds0lo = aPartitionBounds.lo()[0];
-  int64_t aPartitionBounds0hi = aPartitionBounds.hi()[0];
-  int64_t aPartitionBounds1lo = aPartitionBounds.lo()[1];
-  int64_t aPartitionBounds1hi = aPartitionBounds.hi()[1];
   Point<1> lowerBound = Point<1>(0);
   Point<1> upperBound = Point<1>((gridX - 1));
   auto kosIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
@@ -438,15 +662,15 @@ void task_7(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   DomainPointColoring cColoring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t kos = (*itr)[0];
-    Point<2> bStart = Point<2>(aPartitionBounds0lo, (((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + 0 / gridX));
-    Point<2> bEnd = Point<2>(TACO_MIN(((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) - 1) + aPartitionBounds0lo),bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[1]));
+    Point<2> bStart = Point<2>((in * ((b1_dimension + (gridX - 1)) / gridX) + 0 / gridX), (((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX));
+    Point<2> bEnd = Point<2>(TACO_MIN((in * ((b1_dimension + (gridX - 1)) / gridX) + ((b1_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[0]), TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[1]));
     Rect<2> bRect = Rect<2>(bStart, bEnd);
     if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
       bRect = bRect.make_empty();
     }
     bColoring[(*itr)] = bRect;
-    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + 0 / gridX), aPartitionBounds1lo);
-    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)),cDomain.hi()[0]), TACO_MIN(((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) - 1) + aPartitionBounds1lo),cDomain.hi()[1]));
+    Point<2> cStart = Point<2>((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + 0 / gridX), (jn * ((c2_dimension + (gridY - 1)) / gridY) + 0 / gridY));
+    Point<2> cEnd = Point<2>(TACO_MIN((((jn + (in + kos)) % gridX) * ((b2_dimension + (gridX - 1)) / gridX) + ((b2_dimension + (gridX - 1)) / gridX - 1)),cDomain.hi()[0]), TACO_MIN((jn * ((c2_dimension + (gridY - 1)) / gridY) + ((c2_dimension + (gridY - 1)) / gridY - 1)),cDomain.hi()[1]));
     Rect<2> cRect = Rect<2>(cStart, cEnd);
     if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
       cRect = cRect.make_empty();
@@ -468,18 +692,17 @@ void task_7(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
     RegionRequirement cReq = RegionRequirement(csubReg, READ_ONLY, EXCLUSIVE, get_logical_region(c));
     cReq.add_field(FID_VAL);
     cReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-    task_6Args taskArgsRaw;
-    taskArgsRaw.aPartitionBounds0hi = aPartitionBounds0hi;
-    taskArgsRaw.aPartitionBounds0lo = aPartitionBounds0lo;
-    taskArgsRaw.aPartitionBounds1hi = aPartitionBounds1hi;
-    taskArgsRaw.aPartitionBounds1lo = aPartitionBounds1lo;
-    taskArgsRaw.c1_dimension = c1_dimension;
+    task_9Args taskArgsRaw;
+    taskArgsRaw.b1_dimension = b1_dimension;
+    taskArgsRaw.b2_dimension = b2_dimension;
+    taskArgsRaw.c2_dimension = c2_dimension;
     taskArgsRaw.gridX = gridX;
+    taskArgsRaw.gridY = gridY;
     taskArgsRaw.in = in;
     taskArgsRaw.jn = jn;
     taskArgsRaw.kos = kos;
-    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_6Args));
-    TaskLauncher launcher = TaskLauncher(taskID(6), taskArgs);
+    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_9Args));
+    TaskLauncher launcher = TaskLauncher(taskID(9), taskArgs);
     launcher.add_region_requirement(aReq);
     launcher.add_region_requirement(bReq);
     launcher.add_region_requirement(cReq);
@@ -488,56 +711,32 @@ void task_7(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
 
 }
 
-void computeLegion(Context ctx, Runtime* runtime, LogicalRegion a, LogicalRegion b, LogicalRegion c, LogicalPartition aPartition, int32_t gridX) {
-  auto b_index_space = get_index_space(b);
-  int c1_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[0] + 1;
-  auto c_index_space = get_index_space(c);
+void computeLegion(Context ctx, Runtime* runtime, LogicalRegion a, LogicalRegion b, LogicalRegion c, LogicalPartition aPartition, LogicalPartition bPartition, LogicalPartition cPartition, int32_t gridX, int32_t gridY) {
+  int b1_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[0] + 1;
+  int b2_dimension = runtime->get_index_space_domain(get_index_space(b)).hi()[1] + 1;
+  int c2_dimension = runtime->get_index_space_domain(get_index_space(c)).hi()[1] + 1;
 
-  DomainT<2> domain = runtime->get_index_partition_color_space(ctx, get_index_partition(aPartition));
-  auto bDomain = runtime->get_index_space_domain(ctx, b_index_space);
-  auto cDomain = runtime->get_index_space_domain(ctx, c_index_space);
-  DomainPointColoring bColoring = DomainPointColoring();
-  DomainPointColoring cColoring = DomainPointColoring();
-  for (PointInDomainIterator<2> itr = PointInDomainIterator<2>(domain); itr.valid(); itr++) {
-    DomainPoint domPoint = (*itr);
-    auto aPartitionBounds = runtime->get_index_space_domain(runtime->get_logical_subregion_by_color(ctx, aPartition, domPoint).get_index_space());
-    int64_t aPartitionBounds0lo = aPartitionBounds.lo()[0];
-    int64_t aPartitionBounds0hi = aPartitionBounds.hi()[0];
-    int64_t aPartitionBounds1lo = aPartitionBounds.lo()[1];
-    int64_t aPartitionBounds1hi = aPartitionBounds.hi()[1];
-    Point<2> bStart = Point<2>(aPartitionBounds0lo, (0 / gridX));
-    Point<2> bEnd = Point<2>(TACO_MIN(((((aPartitionBounds0hi - aPartitionBounds0lo) + 1) - 1) + aPartitionBounds0lo),bDomain.hi()[0]), TACO_MIN(((gridX - 1) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)),bDomain.hi()[1]));
-    Rect<2> bRect = Rect<2>(bStart, bEnd);
-    if (!bDomain.contains(bRect.lo) || !bDomain.contains(bRect.hi)) {
-      bRect = bRect.make_empty();
-    }
-    bColoring[(*itr)] = bRect;
-    Point<2> cStart = Point<2>((0 / gridX), aPartitionBounds1lo);
-    Point<2> cEnd = Point<2>(TACO_MIN(((gridX - 1) * ((c1_dimension + (gridX - 1)) / gridX) + ((c1_dimension + (gridX - 1)) / gridX - 1)),cDomain.hi()[0]), TACO_MIN(((((aPartitionBounds1hi - aPartitionBounds1lo) + 1) - 1) + aPartitionBounds1lo),cDomain.hi()[1]));
-    Rect<2> cRect = Rect<2>(cStart, cEnd);
-    if (!cDomain.contains(cRect.lo) || !cDomain.contains(cRect.hi)) {
-      cRect = cRect.make_empty();
-    }
-    cColoring[(*itr)] = cRect;
-  }
-  auto bPartition = runtime->create_index_partition(ctx, b_index_space, domain, bColoring, LEGION_ALIASED_COMPLETE_KIND);
-  auto cPartition = runtime->create_index_partition(ctx, c_index_space, domain, cColoring, LEGION_ALIASED_COMPLETE_KIND);
+  Point<2> lowerBound = Point<2>(0, 0);
+  Point<2> upperBound = Point<2>((gridX - 1), (gridY - 1));
+  auto distFusedIndexSpace = runtime->create_index_space(ctx, Rect<2>(lowerBound, upperBound));
+  DomainT<2> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<2>(distFusedIndexSpace));
   RegionRequirement aReq = RegionRequirement(aPartition, 0, READ_WRITE, EXCLUSIVE, get_logical_region(a));
   aReq.add_field(FID_VAL);
   aReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  LogicalPartition bLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(b), bPartition);
-  RegionRequirement bReq = RegionRequirement(bLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
+  RegionRequirement bReq = RegionRequirement(bPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(b));
   bReq.add_field(FID_VAL);
   bReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  LogicalPartition cLogicalPartition = runtime->get_logical_partition(ctx, get_logical_region(c), cPartition);
-  RegionRequirement cReq = RegionRequirement(cLogicalPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
+  RegionRequirement cReq = RegionRequirement(cPartition, 0, READ_ONLY, EXCLUSIVE, get_logical_region(c));
   cReq.add_field(FID_VAL);
   cReq.tag = Mapping::DefaultMapper::VIRTUAL_MAP;
-  task_7Args taskArgsRaw;
-  taskArgsRaw.c1_dimension = c1_dimension;
+  task_10Args taskArgsRaw;
+  taskArgsRaw.b1_dimension = b1_dimension;
+  taskArgsRaw.b2_dimension = b2_dimension;
+  taskArgsRaw.c2_dimension = c2_dimension;
   taskArgsRaw.gridX = gridX;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_7Args));
-  IndexLauncher launcher = IndexLauncher(taskID(7), domain, taskArgs, ArgumentMap());
+  taskArgsRaw.gridY = gridY;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_10Args));
+  IndexLauncher launcher = IndexLauncher(taskID(10), domain, taskArgs, ArgumentMap());
   launcher.add_region_requirement(aReq);
   launcher.add_region_requirement(bReq);
   launcher.add_region_requirement(cReq);
@@ -554,8 +753,8 @@ void registerTacoTasks() {
   }
   {
     TaskVariantRegistrar registrar(taskID(2), "task_2");
-    registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
-    registrar.set_leaf();
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    registrar.set_inner();
     Runtime::preregister_task_variant<task_2>(registrar, "task_2");
   }
   {
@@ -566,14 +765,14 @@ void registerTacoTasks() {
   }
   {
     TaskVariantRegistrar registrar(taskID(4), "task_4");
-    registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
-    registrar.set_leaf();
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    registrar.set_inner();
     Runtime::preregister_task_variant<task_4>(registrar, "task_4");
   }
   {
     TaskVariantRegistrar registrar(taskID(5), "task_5");
     registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
-    registrar.set_inner();
+    registrar.set_leaf();
     Runtime::preregister_task_variant<task_5>(registrar, "task_5");
   }
   {
@@ -584,8 +783,26 @@ void registerTacoTasks() {
   }
   {
     TaskVariantRegistrar registrar(taskID(7), "task_7");
+    registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
+    registrar.set_leaf();
+    Runtime::preregister_task_variant<task_7>(registrar, "task_7");
+  }
+  {
+    TaskVariantRegistrar registrar(taskID(8), "task_8");
+    registrar.add_constraint(ProcessorConstraint(Processor::TOC_PROC));
+    registrar.set_inner();
+    Runtime::preregister_task_variant<task_8>(registrar, "task_8");
+  }
+  {
+    TaskVariantRegistrar registrar(taskID(9), "task_9");
     registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
     registrar.set_inner();
-    Runtime::preregister_task_variant<task_7>(registrar, "task_7");
+    Runtime::preregister_task_variant<task_9>(registrar, "task_9");
+  }
+  {
+    TaskVariantRegistrar registrar(taskID(10), "task_10");
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    registrar.set_inner();
+    Runtime::preregister_task_variant<task_10>(registrar, "task_10");
   }
 }


### PR DESCRIPTION
This commit allows the lowerer to separate the declaration of partitions
from the computation that uses them. For dense tensors, this lets us
declare the necessary partitions (at the top level) for an operation once,
so that we don't need to create top level partitions for every operation.
This should lower the amount of metadata tracking that Legion has to
perform and should hopefully provide a good foundation for sparse
operations that have data dependent partitioning operations.

Fixes #35.