### PR TITLE
*: support multi-dimensional pos arrays for the first dense run

### DIFF
--- a/include/taco/format.h
+++ b/include/taco/format.h
@@ -160,13 +160,17 @@ public:
   friend bool operator!=(const ModeFormat&, const ModeFormat&);
   friend std::ostream& operator<<(std::ostream&, const ModeFormat&);
 
+  template <typename T>
+  bool is() {
+    return std::dynamic_pointer_cast<const T>(this->impl) != nullptr;
+  }
+
 private:
   std::shared_ptr<const ModeFormatImpl> impl;
 
   friend class ModePack;
   friend class Iterator;
 };
-
 
 class ModeFormatPack {
 public:
@@ -210,6 +214,11 @@ const Format COO(int order, bool isUnique = true, bool isOrdered = true,
                  bool isAoS = false, const std::vector<int>& modeOrdering = {});
 const Format LgCOO(int order, bool isUnique = true, bool isOrdered = true,
                    bool isAoS = false, const std::vector<int>& modeOrdering = {});
+
+// LgFormat is a wrapper to construct formats that inserts extra information in each ModeFormat
+// that is needed as there are now some dependencies between level formats.
+Format LgFormat(std::vector<ModeFormat> formats);
+
 /// @}
 
 /// True if all modes are dense.

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -69,6 +69,9 @@ public:
 
   // Special case to identify Dense mode formats.
   bool isDense() const;
+  // Special case to also identify LgSparse formats. We use this to
+  // perform introspection for breaking the "level per level" approach of TACO.
+  bool isLgSparse() const;
 
   /// Properties of level being iterated.
   bool isFull() const;
@@ -142,8 +145,10 @@ public:
   
   /// Return code for level functions that implement coordinate position  
   /// iteration.
+  // TODO (rohany): Delete this function, keeping it right now to hack on things.
   ModeFunction posBounds(const ir::Expr& parentPos) const;
-  ModeFunction posAccess(const ir::Expr& pos, 
+  ModeFunction posBounds(const std::vector<ir::Expr>& parentPositions) const;
+  ModeFunction posAccess(const ir::Expr& pos,
                          const std::vector<ir::Expr>& coords) const;
   
   /// Returns code for level function that implements locate capability.
@@ -161,8 +166,7 @@ public:
   
   /// Return code for level functions that implement append capabilitiy.
   ir::Stmt getAppendCoord(const ir::Expr& p, const ir::Expr& i) const; 
-  ir::Stmt getAppendEdges(const ir::Expr& pPrev, const ir::Expr& pBegin, 
-      const ir::Expr& pEnd) const;
+  ir::Stmt getAppendEdges(const std::vector<ir::Expr>& parentPositions, const ir::Expr& pBegin, const ir::Expr& pEnd) const;
   ir::Expr getSize(const ir::Expr& szPrev) const;
   ir::Stmt getAppendInitEdges(const ir::Expr& pPrevBegin, 
       const ir::Expr& pPrevEnd) const;

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -696,6 +696,10 @@ private:
     std::map<Access, std::vector<ir::Expr>> valuesAccess;
   } valuesAnalyzer;
 
+  // getAllNeededParentPositions get all of the position variables needed for multi-dimensional
+  // access into an iterator.
+  std::vector<ir::Expr> getAllNeededParentPositions(Iterator& iter);
+
   // Some common Legion expressions and types. Symbols that are needed outside of
   // the lowerer are defined in ir.{h, cpp}.
   static inline ir::Expr disjointPart = ir::Symbol::make("LEGION_DISJOINT_COMPLETE_KIND");

--- a/include/taco/lower/mode_format_compressed.h
+++ b/include/taco/lower/mode_format_compressed.h
@@ -21,7 +21,7 @@ public:
   attrQueries(std::vector<IndexVar> parentCoords, 
               std::vector<IndexVar> childCoords) const override;
 
-  ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const override;
+  ModeFunction posIterBounds(std::vector<ir::Expr> parentPositions, Mode mode) const override;
   ModeFunction posIterAccess(ir::Expr pos, std::vector<ir::Expr> coords,
                                      Mode mode) const override;
 
@@ -29,7 +29,7 @@ public:
   
   ir::Stmt getAppendCoord(ir::Expr pos, ir::Expr coord, 
                           Mode mode) const override;
-  ir::Stmt getAppendEdges(ir::Expr parentPos, ir::Expr posBegin, 
+  ir::Stmt getAppendEdges(std::vector<ir::Expr> parentPositions, ir::Expr posBegin,
                           ir::Expr posEnd, Mode mode) const override;
   ir::Expr getSize(ir::Expr parentSize, Mode mode) const override;
   ir::Stmt getAppendInitEdges(ir::Expr parentPosBegin, 

--- a/include/taco/lower/mode_format_impl.h
+++ b/include/taco/lower/mode_format_impl.h
@@ -151,7 +151,9 @@ public:
   /// The position iteration capability's iterator function computes a range
   /// [result[0], result[1]) of positions to iterate over.
   /// `pos_iter_bounds(p_{k−1}) -> begin_{k}, end_{k}`
-  virtual ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const;
+  /// The interface provides a list of parentPositions in case several parent positions
+  /// are needed to access the bounds of the position iteration.
+  virtual ModeFunction posIterBounds(std::vector<ir::Expr> parentPositions, Mode mode) const;
 
   /// The position iteration capability's access function maps a position
   /// iterator variable to a coordinate (result[0]) and reports if a coordinate
@@ -193,8 +195,10 @@ public:
   virtual ir::Stmt
   getAppendCoord(ir::Expr p, ir::Expr i, Mode mode) const;
 
+  // Similarly to posIterBounds, this function also takes a vector of parent
+  // positions in case the level format needs them.
   virtual ir::Stmt
-  getAppendEdges(ir::Expr pPrev, ir::Expr pBegin, ir::Expr pEnd,
+  getAppendEdges(std::vector<ir::Expr> parentPositions, ir::Expr pBegin, ir::Expr pEnd,
                  Mode mode) const;
 
   virtual ir::Expr getSize(ir::Expr parentSize, Mode mode) const;

--- a/include/taco/lower/mode_format_lg_singleton.h
+++ b/include/taco/lower/mode_format_lg_singleton.h
@@ -15,7 +15,7 @@ public:
 
   ModeFormat copy(std::vector<ModeFormat::Property> properties) const override;
 
-  ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const override;
+  ModeFunction posIterBounds(std::vector<ir::Expr> parentPositions, Mode mode) const override;
   ModeFunction posIterAccess(ir::Expr pos, std::vector<ir::Expr> coords,
                              Mode mode) const override;
 

--- a/include/taco/lower/mode_format_rect_compressed.h
+++ b/include/taco/lower/mode_format_rect_compressed.h
@@ -16,18 +16,19 @@ public:
   using ModeFormatImpl::getInsertCoord;
 
   RectCompressedModeFormat();
+  RectCompressedModeFormat(int posDim);
   RectCompressedModeFormat(bool isFull, bool isOrdered,
-                           bool isUnique, bool isZeroless, long long allocSize = LG_DEFAULT_ALLOC_SIZE);
+                           bool isUnique, bool isZeroless, int posDim, long long allocSize = LG_DEFAULT_ALLOC_SIZE);
 
   ModeFormat copy(std::vector<ModeFormat::Property> properties) const override;
 
   // Similarly to the compressed level, this format supports position iterate.
-  ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const override;
+  ModeFunction posIterBounds(std::vector<ir::Expr> parentPos, Mode mode) const override;
   ModeFunction posIterAccess(ir::Expr pos, std::vector<ir::Expr> coords, Mode mode) const override;
 
   // Definitions for insertion into a tensor level.
   ir::Stmt getAppendCoord(ir::Expr pos, ir::Expr coord, Mode mode) const override;
-  ir::Stmt getAppendEdges(ir::Expr parentPos, ir::Expr posBegin, ir::Expr posEnd, Mode mode) const override;
+  ir::Stmt getAppendEdges(std::vector<ir::Expr> parentPositions, ir::Expr posBegin, ir::Expr posEnd, Mode mode) const override;
   ir::Expr getSize(ir::Expr szPrev, Mode mode) const override;
   ir::Stmt getAppendInitEdges(ir::Expr parentPosBegin, ir::Expr parentPosEnd, Mode mode) const override;
   ir::Stmt getAppendInitLevel(ir::Expr parentSize, ir::Expr size, Mode mode) const override;
@@ -40,7 +41,6 @@ public:
   std::vector<ir::Expr> getArrays(ir::Expr tensor, int mode, int level) const override;
   std::vector<ModeRegion> getRegions(ir::Expr tensor, int level) const override;
 protected:
-  // TODO (rohany): I could also maybe use this to manage accessors into the regions?
   enum RECT_COMPRESSED_REGIONS {
     POS = 0,
     CRD,
@@ -52,10 +52,12 @@ protected:
 
   ir::Expr getPosCapacity(Mode mode) const;
   ir::Expr getCoordCapacity(Mode mode) const;
+  ir::Expr packToPoint(const std::vector<ir::Expr>& args) const;
 
   static inline ir::Expr fidRect1 = ir::Symbol::make("FID_RECT_1");
   static inline ir::Expr fidCoord = ir::Symbol::make("FID_COORD");
   const long long allocSize;
+  int posDim = -1;
 };
 
 }

--- a/include/taco/lower/mode_format_singleton.h
+++ b/include/taco/lower/mode_format_singleton.h
@@ -17,7 +17,7 @@ public:
 
   ModeFormat copy(std::vector<ModeFormat::Property> properties) const override;
 
-  ModeFunction posIterBounds(ir::Expr parentPos, Mode mode) const override;
+  ModeFunction posIterBounds(std::vector<ir::Expr> parentPositions, Mode mode) const override;
   ModeFunction posIterAccess(ir::Expr pos, std::vector<ir::Expr> coords,
                              Mode mode) const override;
   

--- a/legion/CMakeLists.txt
+++ b/legion/CMakeLists.txt
@@ -115,6 +115,7 @@ add_cuda_folder(cuda-test)
 
 # Sparse codes.
 add_app_folder(spmv)
+add_app_folder(spttv)
 
 # Add a variety of tests for the generated code.
 

--- a/legion/format-converter/main.cpp
+++ b/legion/format-converter/main.cpp
@@ -1,5 +1,6 @@
 #include "legion.h"
 #include "taco_legion_header.h"
+#include "legion_string_utils.h"
 #include "hdf5_utils.h"
 #include "realm/cmdline.h"
 
@@ -12,18 +13,21 @@ enum TaskIDs {
 // Forward declarations of all generated conversion methods.
 void registerTacoTasks();
 void packLegionCOOToCSR(Context ctx, Runtime* runtime, LegionTensor* T, LegionTensor* TCOO);
+void packLegionCOOToDSS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTensor* TCOO);
+void packLegionCOOToDDS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTensor* TCOO);
 // End declarations.
 
 Realm::Logger logApp("app");
 
 void top_level_task(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  bool roundTrip = false;
+  bool roundTrip = false, dump = false;
   std::string outputFormat, cooFile, outputFile;
   Realm::CommandLineParser parser;
   parser.add_option_string("-coofile", cooFile);
   parser.add_option_string("-format", outputFormat);
   parser.add_option_string("-o", outputFile);
   parser.add_option_bool("-roundTrip", roundTrip);
+  parser.add_option_bool("-dump", dump);
   auto args = Runtime::get_input_args();
   assert(parser.parse_command_line(args.argc, args.argv));
   assert(!cooFile.empty());
@@ -53,13 +57,21 @@ void top_level_task(const Task* task, const std::vector<PhysicalRegion>& regions
   auto output = createSparseTensorForPack<double>(ctx, runtime, format, coo.dims, FID_RECT_1, FID_COORD, FID_VAL);
 
   logApp.info() << "Packing COO to desired format.";
-  // TODO (rohany): For now, we'll use an if-ladder to see what formats we handle.
-  if (outputFormat == "ds") {
-    assert(coo.order == 2);
-    packLegionCOOToCSR(ctx, runtime, &output, &coo);
-  } else {
+
+  // TODO (rohany): Is there any way that we could generate this map programmatically? We could
+  //  probably emit it at the top of the taco generated file?
+  typedef void (*ConvFunc)(Context, Runtime*, LegionTensor*, LegionTensor*);
+  std::map<std::string, ConvFunc> converters = {
+      {"ds", packLegionCOOToCSR},
+      {"dss", packLegionCOOToDSS},
+      {"dds", packLegionCOOToDDS},
+  };
+  auto it = converters.find(outputFormat);
+  if (it == converters.end()) {
     assert(false && "unsupported output format kind");
   }
+  it->second(ctx, runtime, &output, &coo);
+
   logApp.info() << "Done packing COO to desired format.";
 
   logApp.info() << "Dumping output tensor to HDF5 file.";
@@ -71,6 +83,10 @@ void top_level_task(const Task* task, const std::vector<PhysicalRegion>& regions
     // Let's try and load it back in to see if it somewhat round-trips.
     auto test = loadLegionTensorFromHDF5File(ctx, runtime, outputFile, format);
     logApp.info() << test.toString(ctx, runtime);
+  }
+  if (dump) {
+    // Dump out the packed tensor to stdout.
+    printLegionTensor<double>(ctx, runtime, output, format);
   }
 }
 

--- a/legion/format-converter/taco-generated.cpp
+++ b/legion/format-converter/taco-generated.cpp
@@ -8,6 +8,7 @@ typedef FieldAccessor<READ_ONLY,double,1,coord_t,Realm::AffineAccessor<double,1,
 typedef FieldAccessor<READ_WRITE,double,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorRWdouble1;
 typedef FieldAccessor<READ_ONLY,Rect<1>,1,coord_t,Realm::AffineAccessor<Rect<1>,1,coord_t>> AccessorRORect_1_1;
 typedef FieldAccessor<READ_WRITE,Rect<1>,1,coord_t,Realm::AffineAccessor<Rect<1>,1,coord_t>> AccessorRWRect_1_1;
+typedef FieldAccessor<READ_WRITE,Rect<1>,2,coord_t,Realm::AffineAccessor<Rect<1>,2,coord_t>> AccessorRWRect_1_2;
 
 
 void packLegionCOOToCSR(Context ctx, Runtime* runtime, LegionTensor* T, LegionTensor* TCOO) {
@@ -43,11 +44,12 @@ void packLegionCOOToCSR(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
   TCOO_vals = legionMalloc(ctx, runtime, TCOO_vals, TCOO_vals_parent, FID_VAL);
   TCOO_vals_ro_accessor = createAccessor<AccessorROdouble1>(TCOO_vals, FID_VAL);
 
-  T2_pos = legionMalloc(ctx, runtime, T2_pos_parent, T1_dimension, FID_RECT_1);
+  T2_pos = legionMalloc(ctx, runtime, T2_pos, T2_pos_parent, FID_RECT_1);
   T2_pos_accessor = createAccessor<AccessorRWRect_1_1>(T2_pos, FID_RECT_1);
-  T2_pos_accessor[0] = Rect<1>(0, 0);
-  for (int32_t pT2 = 1; pT2 < T1_dimension; pT2++) {
-    T2_pos_accessor[pT2] = Rect<1>(0, 0);
+  DomainT<1> pDomT2 = DomainT<1>(runtime->get_index_space_domain(ctx, T2_pos.get_index_space()));
+  T2_pos_accessor[Point<1>(0)] = Rect<1>(0, -1);
+  for (int32_t pT20 = 0; pT20 < (pDomT2.bounds.hi[0] + 1); pT20++) {
+    T2_pos_accessor[Point<1>(pT20)] = Rect<1>(0, -1);
   }
   int32_t T2_crd_size = 1048576;
   T2_crd = legionMalloc(ctx, runtime, T2_crd_parent, T2_crd_size, FID_COORD);
@@ -57,8 +59,8 @@ void packLegionCOOToCSR(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
   T_vals = legionMalloc(ctx, runtime, T_vals_parent, T_capacity, FID_VAL);
   T_vals_rw_accessor = createAccessor<AccessorRWdouble1>(T_vals, FID_VAL);
 
-  int32_t iTCOO = TCOO1_pos_accessor[0].lo;
-  int32_t pTCOO1_end = TCOO1_pos_accessor[0].hi + 1;
+  int32_t iTCOO = TCOO1_pos_accessor[Point<1>(0)].lo;
+  int32_t pTCOO1_end = TCOO1_pos_accessor[Point<1>(0)].hi + 1;
 
   while (iTCOO < pTCOO1_end) {
     int32_t i = TCOO1_crd_accessor[iTCOO];
@@ -85,17 +87,11 @@ void packLegionCOOToCSR(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
       jT++;
     }
 
-    T2_pos_accessor[i].hi = (jT - pT2_begin) - 1;
+    T2_pos_accessor[Point<1>(i)].lo = pT2_begin;
+    T2_pos_accessor[Point<1>(i)].hi = jT - 1;
     iTCOO = TCOO1_segend;
   }
 
-  int64_t csT2 = 0;
-  for (int64_t pT20 = 0; pT20 < T1_dimension; pT20++) {
-    int64_t numElemsT2 = T2_pos_accessor[pT20].hi;
-    T2_pos_accessor[pT20].lo = csT2 + T2_pos_accessor[pT20].lo;
-    T2_pos_accessor[pT20].hi = csT2 + T2_pos_accessor[pT20].hi;
-    csT2 += numElemsT2 + 1;
-  }
   T->indices[1][1] = getSubRegion(ctx, runtime, T2_crd_parent, Rect<1>(0, (jT - 1)));
 
   T->vals = getSubRegion(ctx, runtime, T_vals_parent, Rect<1>(0, (jT - 1)));
@@ -153,11 +149,12 @@ void packLegionCOOToDSS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
   TCOO_vals = legionMalloc(ctx, runtime, TCOO_vals, TCOO_vals_parent, FID_VAL);
   TCOO_vals_ro_accessor = createAccessor<AccessorROdouble1>(TCOO_vals, FID_VAL);
 
-  T2_pos = legionMalloc(ctx, runtime, T2_pos_parent, T1_dimension, FID_RECT_1);
+  T2_pos = legionMalloc(ctx, runtime, T2_pos, T2_pos_parent, FID_RECT_1);
   T2_pos_accessor = createAccessor<AccessorRWRect_1_1>(T2_pos, FID_RECT_1);
-  T2_pos_accessor[0] = Rect<1>(0, 0);
-  for (int32_t pT2 = 1; pT2 < T1_dimension; pT2++) {
-    T2_pos_accessor[pT2] = Rect<1>(0, 0);
+  DomainT<1> pDomT2 = DomainT<1>(runtime->get_index_space_domain(ctx, T2_pos.get_index_space()));
+  T2_pos_accessor[Point<1>(0)] = Rect<1>(0, -1);
+  for (int32_t pT20 = 0; pT20 < (pDomT2.bounds.hi[0] + 1); pT20++) {
+    T2_pos_accessor[Point<1>(pT20)] = Rect<1>(0, -1);
   }
   int32_t T2_crd_size = 1048576;
   T2_crd = legionMalloc(ctx, runtime, T2_crd_parent, T2_crd_size, FID_COORD);
@@ -166,7 +163,8 @@ void packLegionCOOToDSS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
   int32_t T3_pos_size = 1048576;
   T3_pos = legionMalloc(ctx, runtime, T3_pos_parent, T3_pos_size, FID_RECT_1);
   T3_pos_accessor = createAccessor<AccessorRWRect_1_1>(T3_pos, FID_RECT_1);
-  T3_pos_accessor[0] = Rect<1>(0, 0);
+  DomainT<1> pDomT3 = DomainT<1>(runtime->get_index_space_domain(ctx, T3_pos.get_index_space()));
+  T3_pos_accessor[Point<1>(0)] = Rect<1>(0, -1);
   int32_t T3_crd_size = 1048576;
   T3_crd = legionMalloc(ctx, runtime, T3_crd_parent, T3_crd_size, FID_COORD);
   T3_crd_accessor = createAccessor<AccessorRWint32_t1>(T3_crd, FID_COORD);
@@ -175,8 +173,8 @@ void packLegionCOOToDSS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
   T_vals = legionMalloc(ctx, runtime, T_vals_parent, T_capacity, FID_VAL);
   T_vals_rw_accessor = createAccessor<AccessorRWdouble1>(T_vals, FID_VAL);
 
-  int32_t iTCOO = TCOO1_pos_accessor[0].lo;
-  int32_t pTCOO1_end = TCOO1_pos_accessor[0].hi + 1;
+  int32_t iTCOO = TCOO1_pos_accessor[Point<1>(0)].lo;
+  int32_t pTCOO1_end = TCOO1_pos_accessor[Point<1>(0)].hi + 1;
 
   while (iTCOO < pTCOO1_end) {
     int32_t i = TCOO1_crd_accessor[iTCOO];
@@ -218,8 +216,8 @@ void packLegionCOOToDSS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
         kT++;
       }
 
-      T3_pos_accessor[jT].lo = pT3_begin;
-      T3_pos_accessor[jT].hi = kT - 1;
+      T3_pos_accessor[Point<1>(jT)].lo = pT3_begin;
+      T3_pos_accessor[Point<1>(jT)].hi = kT - 1;
       if (pT3_begin < kT) {
         if (T2_crd_size <= jT) {
           T2_crd = legionRealloc(ctx, runtime, T2_crd_parent, T2_crd, T2_crd_size * 2, FID_COORD);
@@ -232,23 +230,133 @@ void packLegionCOOToDSS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTe
       jTCOO = TCOO2_segend;
     }
 
-    T2_pos_accessor[i].hi = (jT - pT2_begin) - 1;
+    T2_pos_accessor[Point<1>(i)].lo = pT2_begin;
+    T2_pos_accessor[Point<1>(i)].hi = jT - 1;
     iTCOO = TCOO1_segend;
   }
 
-  int64_t csT2 = 0;
-  for (int64_t pT20 = 0; pT20 < T1_dimension; pT20++) {
-    int64_t numElemsT2 = T2_pos_accessor[pT20].hi;
-    T2_pos_accessor[pT20].lo = csT2 + T2_pos_accessor[pT20].lo;
-    T2_pos_accessor[pT20].hi = csT2 + T2_pos_accessor[pT20].hi;
-    csT2 += numElemsT2 + 1;
-  }
   T->indices[1][1] = getSubRegion(ctx, runtime, T2_crd_parent, Rect<1>(0, (jT - 1)));
+
+  T->indices[2][0] = getSubRegion(ctx, runtime, T3_pos_parent, Rect<1>(0, (jT - 1)));
+  T->indices[2][1] = getSubRegion(ctx, runtime, T3_crd_parent, Rect<1>(0, (kT - 1)));
 
   T->vals = getSubRegion(ctx, runtime, T_vals_parent, Rect<1>(0, (kT - 1)));
 
   runtime->unmap_region(ctx, T2_pos);
   runtime->unmap_region(ctx, T2_crd);
+  runtime->unmap_region(ctx, T3_pos);
+  runtime->unmap_region(ctx, T3_crd);
+  runtime->unmap_region(ctx, T_vals);
+  runtime->unmap_region(ctx, TCOO1_pos);
+  runtime->unmap_region(ctx, TCOO1_crd);
+  runtime->unmap_region(ctx, TCOO2_crd);
+  runtime->unmap_region(ctx, TCOO3_crd);
+  runtime->unmap_region(ctx, TCOO_vals);
+}
+
+void packLegionCOOToDDS(Context ctx, Runtime* runtime, LegionTensor* T, LegionTensor* TCOO) {
+  int T1_dimension = T->dims[0];
+  int T2_dimension = T->dims[1];
+  RegionWrapper T3_pos = T->indices[2][0];
+  RegionWrapper T3_crd = T->indices[2][1];
+  auto T3_pos_parent = T->indicesParents[2][0];
+  auto T3_crd_parent = T->indicesParents[2][1];
+  RegionWrapper T_vals = T->vals;
+  auto T_vals_parent = T->valsParent;
+  auto T_vals_rw_accessor = createAccessor<AccessorRWdouble1>(T_vals, FID_VAL);
+  auto T3_pos_accessor = createAccessor<AccessorRWRect_1_2>(T3_pos, FID_RECT_1);
+  auto T3_crd_accessor = createAccessor<AccessorRWint32_t1>(T3_crd, FID_COORD);
+  RegionWrapper TCOO1_pos = TCOO->indices[0][0];
+  RegionWrapper TCOO1_crd = TCOO->indices[0][1];
+  RegionWrapper TCOO2_crd = TCOO->indices[1][0];
+  RegionWrapper TCOO3_crd = TCOO->indices[2][0];
+  auto TCOO1_pos_parent = TCOO->indicesParents[0][0];
+  auto TCOO1_crd_parent = TCOO->indicesParents[0][1];
+  auto TCOO2_crd_parent = TCOO->indicesParents[1][0];
+  auto TCOO3_crd_parent = TCOO->indicesParents[2][0];
+  RegionWrapper TCOO_vals = TCOO->vals;
+  auto TCOO_vals_parent = TCOO->valsParent;
+  auto TCOO_vals_ro_accessor = createAccessor<AccessorROdouble1>(TCOO_vals, FID_VAL);
+  auto TCOO1_pos_accessor = createAccessor<AccessorRORect_1_1>(TCOO1_pos, FID_RECT_1);
+  auto TCOO1_crd_accessor = createAccessor<AccessorROint32_t1>(TCOO1_crd, FID_COORD);
+  auto TCOO2_crd_accessor = createAccessor<AccessorROint32_t1>(TCOO2_crd, FID_COORD);
+  auto TCOO3_crd_accessor = createAccessor<AccessorROint32_t1>(TCOO3_crd, FID_COORD);
+
+  TCOO1_pos = legionMalloc(ctx, runtime, TCOO1_pos, TCOO1_pos_parent, FID_RECT_1);
+  TCOO1_pos_accessor = createAccessor<AccessorRORect_1_1>(TCOO1_pos, FID_RECT_1);
+  TCOO1_crd = legionMalloc(ctx, runtime, TCOO1_crd, TCOO1_crd_parent, FID_COORD);
+  TCOO1_crd_accessor = createAccessor<AccessorROint32_t1>(TCOO1_crd, FID_COORD);
+  TCOO2_crd = legionMalloc(ctx, runtime, TCOO2_crd, TCOO2_crd_parent, FID_COORD);
+  TCOO2_crd_accessor = createAccessor<AccessorROint32_t1>(TCOO2_crd, FID_COORD);
+  TCOO3_crd = legionMalloc(ctx, runtime, TCOO3_crd, TCOO3_crd_parent, FID_COORD);
+  TCOO3_crd_accessor = createAccessor<AccessorROint32_t1>(TCOO3_crd, FID_COORD);
+  TCOO_vals = legionMalloc(ctx, runtime, TCOO_vals, TCOO_vals_parent, FID_VAL);
+  TCOO_vals_ro_accessor = createAccessor<AccessorROdouble1>(TCOO_vals, FID_VAL);
+
+  T3_pos = legionMalloc(ctx, runtime, T3_pos, T3_pos_parent, FID_RECT_1);
+  T3_pos_accessor = createAccessor<AccessorRWRect_1_2>(T3_pos, FID_RECT_1);
+  DomainT<2> pDomT3 = DomainT<2>(runtime->get_index_space_domain(ctx, T3_pos.get_index_space()));
+  T3_pos_accessor[Point<2>(0, 0)] = Rect<1>(0, -1);
+  for (int32_t pT30 = 0; pT30 < (pDomT3.bounds.hi[0] + 1); pT30++) {
+    for (int32_t pT31 = 0; pT31 < (pDomT3.bounds.hi[1] + 1); pT31++) {
+      T3_pos_accessor[Point<2>(pT30, pT31)] = Rect<1>(0, -1);
+    }
+  }
+  int32_t T3_crd_size = 1048576;
+  T3_crd = legionMalloc(ctx, runtime, T3_crd_parent, T3_crd_size, FID_COORD);
+  T3_crd_accessor = createAccessor<AccessorRWint32_t1>(T3_crd, FID_COORD);
+  int32_t kT = 0;
+  int32_t T_capacity = 1048576;
+  T_vals = legionMalloc(ctx, runtime, T_vals_parent, T_capacity, FID_VAL);
+  T_vals_rw_accessor = createAccessor<AccessorRWdouble1>(T_vals, FID_VAL);
+
+  int32_t iTCOO = TCOO1_pos_accessor[Point<1>(0)].lo;
+  int32_t pTCOO1_end = TCOO1_pos_accessor[Point<1>(0)].hi + 1;
+
+  while (iTCOO < pTCOO1_end) {
+    int32_t i = TCOO1_crd_accessor[iTCOO];
+    int32_t TCOO1_segend = iTCOO + 1;
+    while (TCOO1_segend < pTCOO1_end && TCOO1_crd_accessor[TCOO1_segend] == i) {
+      TCOO1_segend++;
+    }
+    int32_t jTCOO = iTCOO;
+
+    while (jTCOO < TCOO1_segend) {
+      int32_t j = TCOO2_crd_accessor[jTCOO];
+      int32_t TCOO2_segend = jTCOO + 1;
+      while (TCOO2_segend < TCOO1_segend && TCOO2_crd_accessor[TCOO2_segend] == j) {
+        TCOO2_segend++;
+      }
+      int32_t pT3_begin = kT;
+
+      for (int32_t kTCOO = jTCOO; kTCOO < TCOO2_segend; kTCOO++) {
+        int32_t k = TCOO3_crd_accessor[kTCOO];
+        if (T_capacity <= kT) {
+          T_vals = legionRealloc(ctx, runtime, T_vals_parent, T_vals, T_capacity * 2, FID_VAL);
+          T_vals_rw_accessor = createAccessor<AccessorRWdouble1>(T_vals, FID_VAL);
+          T_capacity *= 2;
+        }
+        T_vals_rw_accessor[Point<1>(kT)] = TCOO_vals_ro_accessor[Point<1>(kTCOO)];
+        if (T3_crd_size <= kT) {
+          T3_crd = legionRealloc(ctx, runtime, T3_crd_parent, T3_crd, T3_crd_size * 2, FID_COORD);
+          T3_crd_accessor = createAccessor<AccessorRWint32_t1>(T3_crd, FID_COORD);
+          T3_crd_size *= 2;
+        }
+        T3_crd_accessor[kT] = k;
+        kT++;
+      }
+
+      T3_pos_accessor[Point<2>(i, j)].lo = pT3_begin;
+      T3_pos_accessor[Point<2>(i, j)].hi = kT - 1;
+      jTCOO = TCOO2_segend;
+    }
+    iTCOO = TCOO1_segend;
+  }
+
+  T->indices[2][1] = getSubRegion(ctx, runtime, T3_crd_parent, Rect<1>(0, (kT - 1)));
+
+  T->vals = getSubRegion(ctx, runtime, T_vals_parent, Rect<1>(0, (kT - 1)));
+
   runtime->unmap_region(ctx, T3_pos);
   runtime->unmap_region(ctx, T3_crd);
   runtime->unmap_region(ctx, T_vals);

--- a/legion/include/legion_string_utils.h
+++ b/legion/include/legion_string_utils.h
@@ -1,0 +1,94 @@
+#ifndef TACO_LEGION_STRING_UTILS_H
+#define TACO_LEGION_STRING_UTILS_H
+
+#include "legion.h"
+#include "legion_tensor.h"
+#include "taco_legion_header.h"
+
+// Generic function to print out region data. We'll declare this in a header and instantiate
+// a few versions of the function that have pretty output. We have to wrap this in a helper
+// widget to allow for partial specialization.
+template <typename T, int DIM>
+struct PhysicalRegionPrinter {
+  void printPhysicalRegion(Legion::Context ctx, Legion::Runtime* runtime, Legion::PhysicalRegion reg, Legion::FieldID fid);
+};
+
+// We abstract direct use of PhysicalRegionPrinter through this helper method that performs
+// the dispatch of the dimensionality of the region.
+template <typename T>
+void printPhysicalRegion(Legion::Context ctx, Legion::Runtime* runtime, Legion::PhysicalRegion reg, Legion::FieldID fid) {
+  switch (reg.get_logical_region().get_dim()) {
+    case 1: PhysicalRegionPrinter<T, 1>().printPhysicalRegion(ctx, runtime, reg, fid); break;
+    case 2: PhysicalRegionPrinter<T, 2>().printPhysicalRegion(ctx, runtime, reg, fid); break;
+    default:
+      assert(false);
+  }
+}
+
+template <typename T>
+struct PhysicalRegionPrinter<T, 1> {
+  void printPhysicalRegion(Legion::Context ctx, Legion::Runtime* runtime, Legion::PhysicalRegion reg, Legion::FieldID fid) {
+    using namespace Legion;
+    FieldAccessor<READ_ONLY,T,1,coord_t, Realm::AffineAccessor<T, 1, coord_t>> acc(reg, fid);
+    auto dom = runtime->get_index_space_domain<1>(IndexSpaceT<1>(reg.get_logical_region().get_index_space()));
+    for (int i = dom.bounds.lo; i <= dom.bounds.hi; i++) {
+      std::cout << acc[i] << " ";
+    }
+    std::cout << std::endl;
+  }
+};
+
+template <typename T>
+struct PhysicalRegionPrinter<T, 2> {
+  void printPhysicalRegion(Legion::Context ctx, Legion::Runtime* runtime, Legion::PhysicalRegion reg, Legion::FieldID fid) {
+    using namespace Legion;
+    FieldAccessor<READ_ONLY,T,2,coord_t, Realm::AffineAccessor<T, 2, coord_t>> acc(reg, fid);
+    auto dom = runtime->get_index_space_domain<2>(IndexSpaceT<2>(reg.get_logical_region().get_index_space()));
+    for (int i = dom.bounds.lo[0]; i <= dom.bounds.hi[0]; i++) {
+      for (int j = dom.bounds.lo[1]; j <= dom.bounds.hi[1]; j++) {
+        std::cout << acc[Point<2>(i, j)] << " ";
+      }
+      std::cout << std::endl;
+    }
+  }
+};
+
+template<typename T>
+void printLegionTensor(Legion::Context ctx, Legion::Runtime* runtime, LegionTensor& tensor, std::vector<LegionTensorLevelFormat> format) {
+  // For each level in the tensor, map the regions and print them.
+  for (size_t i = 0; i < format.size(); i++) {
+    switch (format[i]) {
+      case Dense:
+        break; // Nothing to do for dense levels.
+      case Sparse: {
+        // Print out the crd and pos arrays here.
+        auto pos = legionMalloc(ctx, runtime, tensor.indices[i][0], tensor.indicesParents[i][0], FID_RECT_1);
+        auto crd = legionMalloc(ctx, runtime, tensor.indices[i][1], tensor.indicesParents[i][1], FID_COORD);
+        std::cout << "pos " << i << ":" << std::endl;
+        printPhysicalRegion<Legion::Rect<1>>(ctx, runtime, pos, FID_RECT_1);
+        std::cout << "crd " << i << ":" << std::endl;
+        printPhysicalRegion<int32_t>(ctx, runtime, crd, FID_COORD);
+        runtime->unmap_region(ctx, pos);
+        runtime->unmap_region(ctx, crd);
+        break;
+      }
+      case Singleton: {
+        // Print out the crd array.
+        auto crd = legionMalloc(ctx, runtime, tensor.indices[i][0], tensor.indicesParents[i][0], FID_COORD);
+        std::cout << "crd " << i << ":" << std::endl;
+        printPhysicalRegion<int32_t>(ctx, runtime, crd, FID_COORD);
+        runtime->unmap_region(ctx, crd);
+        break;
+      }
+      default:
+        assert(false);
+        break;
+    }
+  }
+  // Finally map the values.
+  auto vals = legionMalloc(ctx, runtime, tensor.vals, tensor.valsParent, FID_VAL);
+  std::cout << "vals " << ":" << std::endl;
+  printPhysicalRegion<T>(ctx, runtime, vals, FID_VAL);
+  runtime->unmap_region(ctx, vals);
+}
+#endif

--- a/legion/include/legion_tensor.h
+++ b/legion/include/legion_tensor.h
@@ -238,5 +238,4 @@ LegionTensor createSparseTensorForPack(Legion::Context ctx, Legion::Runtime* run
   return result;
 }
 
-
 #endif //TACO_LEGION_TENSOR_H

--- a/legion/include/string_utils.h
+++ b/legion/include/string_utils.h
@@ -50,5 +50,4 @@ toString(const T &val) {
   return sstream.str();
 }
 
-
 #endif // TACO_LEGION_STRINGS_H

--- a/legion/spmv/main.cpp
+++ b/legion/spmv/main.cpp
@@ -4,6 +4,7 @@
 #include "realm/cmdline.h"
 #include "mappers/default_mapper.h"
 #include "legion_utils.h"
+#include "legion_string_utils.h"
 
 using namespace Legion;
 using namespace Legion::Mapping;
@@ -106,13 +107,7 @@ void top_level_task(const Task* task, const std::vector<PhysicalRegion>& regions
   LEGION_PRINT_ONCE(runtime, ctx, stdout, "Average execution time: %lf ms\n", avgTime);
 
   if (dump) {
-    auto yreg = legionMalloc(ctx, runtime, y.vals, y.valsParent, FID_VAL);
-    FieldAccessor<READ_WRITE,valType,1,coord_t, Realm::AffineAccessor<valType, 1, coord_t>> yrw(yreg, FID_VAL);
-    for (int i = 0; i < y.dims[0]; i++) {
-      std::cout << yrw[i] << " ";
-    }
-    std::cout << std::endl;
-    runtime->unmap_region(ctx, yreg);
+    printLegionTensor<valType>(ctx, runtime, y, {Dense});
   }
 
   // Delete the partition pack.

--- a/legion/spmv/taco-generated.cpp
+++ b/legion/spmv/taco-generated.cpp
@@ -114,7 +114,7 @@ void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
     if (i >= (io + 1) * ((B1_dimension + (pieces - 1)) / pieces - 0 / pieces))
       continue;
 
-    for (int32_t jB = B2_pos_accessor[i].lo; jB < (B2_pos_accessor[i].hi + 1); jB++) {
+    for (int32_t jB = B2_pos_accessor[Point<1>(i)].lo; jB < (B2_pos_accessor[Point<1>(i)].hi + 1); jB++) {
       int32_t j = B2_crd_accessor[jB];
       a_vals_rw_accessor[Point<1>(i)] = a_vals_rw_accessor[Point<1>(i)] + B_vals_ro_accessor[Point<1>(jB)] * c_vals_ro_accessor[Point<1>(j)];
     }

--- a/src/index_notation/transformations.cpp
+++ b/src/index_notation/transformations.cpp
@@ -730,6 +730,11 @@ Distribute::Distribute(std::vector<IndexVar> original, std::vector<IndexVar> dis
 IndexStmt Distribute::apply(IndexStmt stmt, std::string* reason) const {
   INIT_REASON(reason);
 
+  // Sanity check some user-provided input sizes.
+  taco_iassert(this->content->original.size() == this->content->distVars.size());
+  taco_iassert(this->content->original.size() == this->content->innerVars.size());
+  taco_iassert(this->content->original.size() == size_t(this->content->grid.getDim()));
+
   ProvenanceGraph pg(stmt);
 
   OutputRaceStrategy raceStrategy = OutputRaceStrategy::NoRaces;

--- a/src/lower/mode_format_compressed.cpp
+++ b/src/lower/mode_format_compressed.cpp
@@ -77,8 +77,10 @@ std::vector<AttrQuery> CompressedModeFormat::attrQueries(
   return {AttrQuery(groupBy, {AttrQuery::Attr(std::make_tuple("nnz", AttrQuery::COUNT, aggregatedCoords))})};
 }
 
-ModeFunction CompressedModeFormat::posIterBounds(Expr parentPos, 
+ModeFunction CompressedModeFormat::posIterBounds(std::vector<Expr> parentPositions,
                                                  Mode mode) const {
+  assert(parentPositions.size() == 1);
+  auto parentPos = parentPositions[0];
   Expr pbegin = Load::make(getPosArray(mode.getModePack()), parentPos);
   Expr pend = Load::make(getPosArray(mode.getModePack()),
                          ir::Add::make(parentPos, 1));
@@ -119,8 +121,10 @@ Stmt CompressedModeFormat::getAppendCoord(Expr p, Expr i, Mode mode) const {
   return Block::make({maybeResizeIdx, storeIdx});
 }
 
-Stmt CompressedModeFormat::getAppendEdges(Expr pPrev, Expr pBegin, Expr pEnd, 
+Stmt CompressedModeFormat::getAppendEdges(std::vector<Expr> parentPositions, Expr pBegin, Expr pEnd,
                                           Mode mode) const {
+  taco_iassert(parentPositions.size() == 1);
+  auto pPrev = parentPositions[0];
   Expr posArray = getPosArray(mode.getModePack());
   ModeFormat parentModeType = mode.getParentModeType();
   Expr edges = (!parentModeType.defined() || parentModeType.hasAppend())

--- a/src/lower/mode_format_impl.cpp
+++ b/src/lower/mode_format_impl.cpp
@@ -186,7 +186,7 @@ ModeFunction ModeFormatImpl::coordBounds(ir::Expr parentPos,
   return ModeFunction();
 }
 
-ModeFunction ModeFormatImpl::posIterBounds(ir::Expr parentPos, Mode mode) const {
+ModeFunction ModeFormatImpl::posIterBounds(std::vector<ir::Expr> parentPositions, Mode mode) const {
   return ModeFunction();
 }
 
@@ -231,7 +231,7 @@ Stmt ModeFormatImpl::getAppendCoord(Expr p, Expr i,
   return Stmt();
 }
 
-Stmt ModeFormatImpl::getAppendEdges(Expr pPrev, Expr pBegin,
+Stmt ModeFormatImpl::getAppendEdges(std::vector<Expr> parentPositions, Expr pBegin,
     Expr pEnd, Mode mode) const {
   return Stmt();
 }

--- a/src/lower/mode_format_lg_singleton.cpp
+++ b/src/lower/mode_format_lg_singleton.cpp
@@ -58,8 +58,10 @@ ModeFormat LgSingletonModeFormat::copy(
   return ModeFormat(singletonVariant);
 }
 
-ModeFunction LgSingletonModeFormat::posIterBounds(Expr parentPos,
+ModeFunction LgSingletonModeFormat::posIterBounds(std::vector<Expr> parentPositions,
                                                 Mode mode) const {
+  taco_iassert(parentPositions.size() == 1);
+  auto parentPos = parentPositions[0];
   return ModeFunction(Stmt(), {parentPos, ir::Add::make(parentPos, 1)});
 }
 

--- a/src/lower/mode_format_singleton.cpp
+++ b/src/lower/mode_format_singleton.cpp
@@ -64,8 +64,10 @@ ModeFormat SingletonModeFormat::copy(
   return ModeFormat(singletonVariant);
 }
 
-ModeFunction SingletonModeFormat::posIterBounds(Expr parentPos, 
+ModeFunction SingletonModeFormat::posIterBounds(std::vector<Expr> parentPositions,
                                                 Mode mode) const {
+  taco_iassert(parentPositions.size() == 1);
+  auto parentPos = parentPositions[0];
   return ModeFunction(Stmt(), {parentPos, ir::Add::make(parentPos, 1)});
 }
 


### PR DESCRIPTION
This commit supports mutli-dimensional pos arrays for when the
multi-dimensional array occurs without a sparse level above it (i.e. the
multi-dimensional pos arrays all have a non-variable size first
dimension). In particular, we
* Extend iteration for pos arrays to access the corresponding position
* Extend assembly rules for support multiple dimensions as well