### PR TITLE
*: support GPU workspaces local to an FB memory in DISTAL

### DIFF
--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -496,6 +496,12 @@ protected:
       ir::Stmt& unpackTensorData
   );
 
+  // loweringToGPU denotes whether this Lowerer is configured to lower to GPUs. It uses
+  // a combination of the static should_use_CUDA_codegen() function and containsGPULoops.
+  bool loweringToGPU();
+  // containsGPULoops is true if the target IndexStmt contains GPU parallelized loops.
+  bool containsGPULoops = false;
+
 private:
   bool assemble;
   bool compute;
@@ -518,6 +524,10 @@ private:
 
   // Set of tensors that will be written to.
   std::set<TensorVar> resultTensors;
+  // A set of tensors that are distributed. This set contains the input
+  // and output tensors, but does not contain any temporary workspaces
+  // that are local to a single memory.
+  std::set<TensorVar> legionTensors;
 
   struct TemporaryArrays {
     ir::Expr values;

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -3453,18 +3453,18 @@ IndexStmt generatePackCOOStmt(TensorVar tensor,
 
 
 bool preservesNonZeroStructure(IndexStmt stmt, NonZeroAnalyzerResult& res) {
-  // TODO (rohany): Handle when the statement can contain workspaces.
-
   // We have to use a unique_ptr here to get around the overloaded operator=
   // on Access types.
   std::unique_ptr<Access> resultAccess = nullptr;
   // First, let's find the output access.
   match(stmt, std::function<void(const AssignmentNode*)>([&](const AssignmentNode* node){
-    // There should only be one output access. If this assertion fires,
-    // it's likely because the input statement contains workspaces.
+    // There should only be one output access.
     taco_iassert(!resultAccess);
     resultAccess = std::make_unique<Access>(node->lhs);
+  }), std::function<void(const WhereNode*, Matcher*)>([&](const WhereNode* node, Matcher* m) {
+    m->match(node->consumer);
   }));
+
   // Some expressions don't have assignments, and thus won't have an RHS to consider.
   if (resultAccess == nullptr) {
     return false;


### PR DESCRIPTION
This commit includes several bugfixes and tying up of loose ends to
support workspaces in DISTAL (which have been largely ignored by me
since the beginning of the project). The commits have been tested only
for GPUs, so it's likely that the current code does not work for CPUs,
but my experience so far has indicated that the bugs around this area
are small, so if some kernels need a CPU workspace then further work can
be put in to fix those bugs.