### PR TITLE
*: introduce format abstraction for partitioning, distribute position space

### DIFF
--- a/include/taco/ir/ir.h
+++ b/include/taco/ir/ir.h
@@ -994,6 +994,9 @@ extern ir::Expr ctx;
 extern ir::Expr runtime;
 extern ir::Expr AffineProjectionBot;
 extern ir::Expr GPUFBMem;
+extern ir::Expr disjointPart;
+extern ir::Expr aliasedPart;
+extern ir::Expr computePart;
 
 }}
 #endif

--- a/include/taco/lower/iterator.h
+++ b/include/taco/lower/iterator.h
@@ -225,7 +225,10 @@ public:
   Iterator getIndexSetIterator() const;
 
   /// Methods for creating and manipulating partitions for distribution.
-  ModeFunction getCreateInitialPartition() const;
+  ir::Stmt getInitializePosColoring() const;
+  ir::Stmt getCreatePosColoringEntry(ir::Expr domainPoint, ir::Expr lowerBound, ir::Expr upperBound) const;
+  ir::Stmt getFinalizePosColoring() const;
+  ModeFunction getCreatePartitionWithPosColoring(ir::Expr domain, ir::Expr partitionColor) const;
   ModeFunction getPartitionFromParent(ir::Expr parentPartition, ir::Expr partitionColor) const;
   ModeFunction getPartitionFromChild(ir::Expr childPartition, ir::Expr partitionColor) const;
 

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -772,9 +772,6 @@ private:
 
   // Some common Legion expressions and types. Symbols that are needed outside of
   // the lowerer are defined in ir.{h, cpp}.
-  static inline ir::Expr disjointPart = ir::Symbol::make("LEGION_DISJOINT_COMPLETE_KIND");
-  static inline ir::Expr aliasedPart = ir::Symbol::make("LEGION_ALIASED_COMPLETE_KIND");
-  static inline ir::Expr computePart = ir::Symbol::make("LEGION_COMPUTE_KIND");
   static inline ir::Expr readOnly = ir::Symbol::make("READ_ONLY");
   static inline ir::Expr readWrite = ir::Symbol::make("READ_WRITE");
   static inline ir::Expr exclusive = ir::Symbol::make("EXCLUSIVE");

--- a/include/taco/lower/mode_format_impl.h
+++ b/include/taco/lower/mode_format_impl.h
@@ -273,14 +273,31 @@ public:
   /// replication as those child jobs are going to be cheaper to launch.
   ///
   /// Level functions related to partitioning. Very much a WIP.
-  ///
-  /// The last element of each mode function is the partition to pass down to the next level.
-  /// {@
-  // TODO (rohany): I'm not sure what this function looks like yet, but the point
-  //  here is that you'll make an initial partition of an index space, and then
-  //  that is used to cascade down or up. Intuitively, it seems like this function
-  //  needs to take in bounds or something.
-  virtual ModeFunction getCreateInitialPartition(Mode mode) const;
+
+  // This group of functions contains capabilities to perform a partitioning
+  // of the position space of a tensor mode.
+
+  // Initialize data structures needed to create a coloring of the position space.
+  virtual ir::Stmt getInitializePosColoring(Mode mode) const;
+  // Create an entry in a position space coloring given the domain point, and the
+  // upper and lower bounds of the position space accessed.
+  virtual ir::Stmt getCreatePosColoringEntry(Mode mode, ir::Expr domainPoint, ir::Expr lowerBound, ir::Expr upperBound) const;
+  // Finalize any data structures needed to create a coloring of the position space.
+  virtual ir::Stmt getFinalizePosColoring(Mode mode) const;
+  // Create an initial partition of this format level using the created coloring
+  // from above. This function returns a ModeFunction where the first n elements
+  // are a partition for each region in the mode (i.e. n == this->getRegions().size()).
+  // The last two elements are an initial partition to use as an upwards partition
+  // and a downwards partition.
+  virtual ModeFunction getCreatePartitionWithPosColoring(Mode mode, ir::Expr domain, ir::Expr partitionColor) const;
+
+  // Analogously to the position space coloring methods, there should be a corresponding
+  // set of methods to color and partition a tensor level via a coordinate space. However,
+  // this would ideally be implemented by Dense levels that are allowed to span multiple
+  // dimensions and correspond exactly to the DenseFormatRuns in the implementation. So
+  // for now, the Lowerer handles these cases explicitly, but in a different implementation
+  // this indirection could be used.
+
   // The idea here is that given an IndexPartition of an object, the resulting
   // ModeFunction computes a partition of each array in the mode, and returns
   // the partition to use to partition the lower levels of the tree.

--- a/include/taco/lower/mode_format_rect_compressed.h
+++ b/include/taco/lower/mode_format_rect_compressed.h
@@ -35,6 +35,10 @@ public:
   ir::Stmt getAppendFinalizeLevel(ir::Expr parentPos, ir::Expr parentSize, ir::Expr size, Mode mode) const override;
 
   // Partitioning capabilities.
+  ir::Stmt getInitializePosColoring(Mode mode) const override;
+  ir::Stmt getFinalizePosColoring(Mode mode) const override;
+  ir::Stmt getCreatePosColoringEntry(Mode mode, ir::Expr domainPoint, ir::Expr lowerBound, ir::Expr upperBound) const override;
+  ModeFunction getCreatePartitionWithPosColoring(Mode mode, ir::Expr domain, ir::Expr partitionColor) const override;
   ModeFunction getPartitionFromParent(ir::Expr parentPartition, Mode mode, ir::Expr partitionColor) const override;
   ModeFunction getPartitionFromChild(ir::Expr childPartition, Mode mode, ir::Expr partitionColor) const override;
 
@@ -58,7 +62,14 @@ protected:
   ir::Expr getCoordCapacity(Mode mode) const;
   ir::Expr packToPoint(const std::vector<ir::Expr>& args) const;
   ir::Expr getPosBounds(Mode mode) const;
+  ir::Expr getCrdBounds(Mode mode) const;
   ir::Stmt initPosBounds(Mode mode) const;
+  ir::Stmt initCrdBounds(Mode mode) const;
+  ir::Expr getCrdColoring(Mode mode) const;
+  ir::Expr getModeVar(Mode mode, const std::string varName, Datatype type) const;
+
+  ModeFunction partitionPosFromCrd(Mode mode, ir::Expr crdIndexPartition,
+                                   std::function<std::vector<ir::Expr>(std::vector<ir::Expr>)> maybeAddColor) const;
 
   // hasSparseAncestor returns true if there is a sparse mode
   // above this mode, i.e. it returns false if all parent levels

--- a/legion/sddmm/taco-generated.cpp
+++ b/legion/sddmm/taco-generated.cpp
@@ -1,6 +1,7 @@
 #include "taco_legion_header.h"
 #include "taco_mapper.h"
 #define TACO_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))
+#define TACO_MAX(_a,_b) ((_a) < (_b) ? (_b) : (_a))
 using namespace Legion;
 typedef FieldAccessor<READ_ONLY,int32_t,1,coord_t,Realm::AffineAccessor<int32_t,1,coord_t>> AccessorROint32_t1;
 typedef FieldAccessor<READ_ONLY,double,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorROdouble1;
@@ -45,32 +46,33 @@ partitionPackForcomputeLegion* partitionForcomputeLegion(Context ctx, Runtime* r
   Point<1> upperBound = Point<1>((pieces - 1));
   auto koIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
   DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(koIndexSpace));
-  auto BValsDomain = runtime->get_index_space_domain(ctx, get_index_space(B_vals));
-  auto BValsColoring = DomainPointColoring();
+  DomainT<1> B2_crd_domain = runtime->get_index_space_domain(ctx, B2_crd.get_index_space());
+  DomainPointColoring B2_crd_coloring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t ko = (*itr)[0];
-    Point<1> BStart = Point<1>((ko * ((B2Size + (pieces - 1)) / pieces) + 0 / pieces));
-    Point<1> BEnd = Point<1>(TACO_MIN((ko * ((B2Size + (pieces - 1)) / pieces) + ((B2Size + (pieces - 1)) / pieces - 1)), BValsDomain.hi()[0]));
-    Rect<1> BRect = Rect<1>(BStart, BEnd);
-    if (!BValsDomain.contains(BRect.lo) || !BValsDomain.contains(BRect.hi)) {
-      BRect = BRect.make_empty();
+    Point<1> B2CrdStart = Point<1>((ko * ((B2Size + (pieces - 1)) / pieces)));
+    Point<1> B2CrdEnd = Point<1>(TACO_MAX((ko * ((B2Size + (pieces - 1)) / pieces) + ((B2Size + (pieces - 1)) / pieces - 1)),B2_crd_domain.bounds.hi[0]));
+    Rect<1> B2CrdRect = Rect<1>(B2CrdStart, B2CrdEnd);
+    if (!B2_crd_domain.contains(B2CrdRect.lo) || !B2_crd_domain.contains(B2CrdRect.hi)) {
+      B2CrdRect = B2CrdRect.make_empty();
     }
-    BValsColoring[(*itr)] = BRect;
+    B2_crd_coloring[(*itr)] = B2CrdRect;
   }
-  IndexPartition BValsIndexPart = runtime->create_index_partition(ctx, get_index_space(B_vals), domain, BValsColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  LogicalPartition BValsLogicalPart = runtime->get_logical_partition(ctx, B_vals, BValsIndexPart);
-  LogicalPartition crdPartB2 = copyPartition(ctx, runtime, BValsLogicalPart, B2_crd);
+  IndexPartition B2_crd_index_part = runtime->create_index_partition(ctx, B2_crd.get_index_space(), domain, B2_crd_coloring, LEGION_COMPUTE_KIND);
+  LogicalPartition B2_crd_part = runtime->get_logical_partition(ctx, B2_crd, B2_crd_index_part);
   IndexPartition posSparsePartB2 = runtime->create_partition_by_preimage_range(
     ctx,
-    crdPartB2.get_index_partition(),
+    B2_crd_index_part,
     B2_pos,
     B2_pos_parent,
     FID_RECT_1,
-    runtime->get_index_partition_color_space_name(ctx, crdPartB2.get_index_partition())
+    runtime->get_index_partition_color_space_name(ctx, B2_crd_index_part)
   );
   IndexPartition posIndexPartB2 = densifyPartition(ctx, runtime, get_index_space(B2_pos), posSparsePartB2);
   LogicalPartition posPartB2 = runtime->get_logical_partition(ctx, B2_pos, posIndexPartB2);
-  LogicalPartition AValsLogicalPart = copyPartition(ctx, runtime, BValsLogicalPart, A_vals);
+  LogicalPartition BValsLogicalPart = copyPartition(ctx, runtime, B2_crd_part, B_vals);
+  IndexPartition BDenseRun0Partition = copyPartition(ctx, runtime, posPartB2, B_dense_run_0);
+  LogicalPartition AValsLogicalPart = copyPartition(ctx, runtime, B2_crd_part, A_vals);
   LogicalPartition crdPartA2 = copyPartition(ctx, runtime, AValsLogicalPart, A2_crd);
   IndexPartition posSparsePartA2 = runtime->create_partition_by_preimage_range(
     ctx,
@@ -83,7 +85,6 @@ partitionPackForcomputeLegion* partitionForcomputeLegion(Context ctx, Runtime* r
   IndexPartition posIndexPartA2 = densifyPartition(ctx, runtime, get_index_space(A2_pos), posSparsePartA2);
   LogicalPartition posPartA2 = runtime->get_logical_partition(ctx, A2_pos, posIndexPartA2);
   IndexPartition ADenseRun0Partition = copyPartition(ctx, runtime, posPartA2, A_dense_run_0);
-  IndexPartition BDenseRun0Partition = copyPartition(ctx, runtime, posPartB2, B_dense_run_0);
   IndexPartition CDenseRun0Partition = AffineProjection(0).apply(ctx, runtime, BDenseRun0Partition, C_dense_run_0);
   auto C_vals_partition = copyPartition(ctx, runtime, CDenseRun0Partition, get_logical_region(C_vals));
   auto computePartitions = new(partitionPackForcomputeLegion);
@@ -96,7 +97,7 @@ partitionPackForcomputeLegion* partitionForcomputeLegion(Context ctx, Runtime* r
   computePartitions->BPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
   computePartitions->BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions->BPartition.indicesPartitions[1].push_back(posPartB2);
-  computePartitions->BPartition.indicesPartitions[1].push_back(crdPartB2);
+  computePartitions->BPartition.indicesPartitions[1].push_back(B2_crd_part);
   computePartitions->BPartition.valsPartition = BValsLogicalPart;
   computePartitions->BPartition.denseLevelRunPartitions[0] = BDenseRun0Partition;
   computePartitions->CPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
@@ -146,20 +147,21 @@ void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
     return ;
 
   DomainT<1> B2PosDomain = runtime->get_index_space_domain(ctx, get_index_space(B2_pos));
+  DomainT<1> B2CrdDomain = runtime->get_index_space_domain(ctx, get_index_space(B2_crd));
   int32_t pB2_begin = B2PosDomain.bounds.lo;
   int32_t pB2_end = B2PosDomain.bounds.hi;
   int64_t pointID1 = ko;
   #pragma omp parallel for schedule(static)
-  for (int32_t kio = (0 / pieces) / 2048; kio < (((B2Size + (pieces - 1)) / pieces + 2047) / 2048); kio++) {
+  for (int32_t kio = 0; kio < (((B2Size + (pieces - 1)) / pieces + 2047) / 2048); kio++) {
     int64_t pointID2 = pointID1 * (((B2Size + (pieces - 1)) / pieces + 2047) / 2048) + kio;
-    int32_t ki = kio * 2048 + 0 / pieces;
+    int32_t ki = kio * 2048;
     int32_t kposB = ko * ((B2Size + (pieces - 1)) / pieces) + ki;
     int32_t i_pos = taco_binarySearchBefore(B2_pos_accessor, pB2_begin, pB2_end, kposB);
     int32_t i = i_pos;
     for (int32_t kii = 0; kii < 2048; kii++) {
-      int32_t ki = (kio * 2048 + kii) + 0 / pieces;
+      int32_t ki = kio * 2048 + kii;
       int32_t kposB = ko * ((B2Size + (pieces - 1)) / pieces) + ki;
-      if (kposB >= (ko + 1) * ((B2Size + (pieces - 1)) / pieces - 0 / pieces))
+      if (kposB >= (ko + 1) * ((B2Size + (pieces - 1)) / pieces))
         continue;
 
       if (kposB >= B2Size)

--- a/legion/spmm/taco-generated.cpp
+++ b/legion/spmm/taco-generated.cpp
@@ -1,173 +1,86 @@
 #include "taco_legion_header.h"
 #include "taco_mapper.h"
 #define TACO_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))
+#define TACO_MAX(_a,_b) ((_a) < (_b) ? (_b) : (_a))
 using namespace Legion;
 typedef FieldAccessor<READ_ONLY,int32_t,1,coord_t,Realm::AffineAccessor<int32_t,1,coord_t>> AccessorROint32_t1;
 typedef FieldAccessor<READ_ONLY,double,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorROdouble1;
 typedef FieldAccessor<READ_ONLY,Rect<1>,1,coord_t,Realm::AffineAccessor<Rect<1>,1,coord_t>> AccessorRORect_1_1;
 typedef FieldAccessor<READ_ONLY,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t>> AccessorROdouble2;
-typedef FieldAccessor<READ_WRITE,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t>> AccessorRWdouble2;
+typedef ReductionAccessor<SumReduction<double>,true,2,coord_t,Realm::AffineAccessor<double,2,coord_t>> AccessorReducedouble2;
 
-struct task_2Args {
-  int32_t B2_dimension;
-  int32_t C2_dimension;
-  IndexSpace C_dense_run_0;
-  int32_t gx;
-};
 struct partitionPackForcomputeLegion {
   LegionTensorPartition APartition;
   LegionTensorPartition BPartition;
 };
 
-struct task_3Args {
+struct task_1Args {
   int32_t A1_dimension;
   int32_t A2_dimension;
-  int32_t B1_dimension;
-  int32_t C1_dimension;
-  int32_t C2_dimension;
-  int32_t gx;
-  int32_t io;
-  int32_t jo;
-  int64_t pointID1;
-};
-struct task_4Args {
-  int32_t A1_dimension;
-  int32_t A2_dimension;
-  int32_t B1_dimension;
+  int64_t B2Size;
   int32_t C1_dimension;
   int32_t C2_dimension;
   int32_t gx;
 };
-
-void task_2(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion A_vals = regions[0];
-  LogicalRegion A_vals_parent = regions[0].get_logical_region();
-  PhysicalRegion B2_pos = regions[1];
-  LogicalRegion B2_pos_parent = regions[1].get_logical_region();
-  PhysicalRegion B2_crd = regions[2];
-  LogicalRegion B2_crd_parent = regions[2].get_logical_region();
-  PhysicalRegion B_vals = regions[3];
-  LogicalRegion B_vals_parent = regions[3].get_logical_region();
-  PhysicalRegion C_vals = regions[4];
-  LogicalRegion C_vals_parent = regions[4].get_logical_region();
-
-  int32_t io = task->index_point[0];
-  task_2Args* args = (task_2Args*)(task->args);
-  int32_t B2_dimension = args->B2_dimension;
-  int32_t C2_dimension = args->C2_dimension;
-  IndexSpace C_dense_run_0 = args->C_dense_run_0;
-  int32_t gx = args->gx;
-
-
-  int64_t pointID1 = io;
-  Point<1> lowerBound = Point<1>(0);
-  Point<1> upperBound = Point<1>((gx - 1));
-  auto joIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
-  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(joIndexSpace));
-  auto CDomain = runtime->get_index_space_domain(ctx, C_dense_run_0);
-  DomainPointColoring CColoring = DomainPointColoring();
-  for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
-    int32_t jo = (*itr)[0];
-    Point<2> CStart = Point<2>(0, (jo * ((C2_dimension + (gx - 1)) / gx) + 0 / gx));
-    Point<2> CEnd = Point<2>(TACO_MIN(B2_dimension, CDomain.hi()[0]), TACO_MIN((jo * ((C2_dimension + (gx - 1)) / gx) + ((C2_dimension + (gx - 1)) / gx - 1)), CDomain.hi()[1]));
-    Rect<2> CRect = Rect<2>(CStart, CEnd);
-    if (!CDomain.contains(CRect.lo) || !CDomain.contains(CRect.hi)) {
-      CRect = CRect.make_empty();
-    }
-    CColoring[(*itr)] = CRect;
-  }
-  auto CPartition = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto C_vals_partition = copyPartition(ctx, runtime, CPartition, get_logical_region(C_vals), pointID1);
-}
 
 partitionPackForcomputeLegion* partitionForcomputeLegion(Context ctx, Runtime* runtime, LegionTensor* A, LegionTensor* B, LegionTensor* C, int32_t gx) {
   RegionWrapper A_vals = A->vals;
-  auto A_vals_parent = A->valsParent;
   IndexSpace A_dense_run_0 = A->denseLevelRuns[0];
-  int B1_dimension = B->dims[0];
-  int B2_dimension = B->dims[1];
   RegionWrapper B2_pos = B->indices[1][0];
   RegionWrapper B2_crd = B->indices[1][1];
   auto B2_pos_parent = B->indicesParents[1][0];
-  auto B2_crd_parent = B->indicesParents[1][1];
   RegionWrapper B_vals = B->vals;
-  auto B_vals_parent = B->valsParent;
   IndexSpace B_dense_run_0 = B->denseLevelRuns[0];
-  int C2_dimension = C->dims[1];
-  RegionWrapper C_vals = C->vals;
-  auto C_vals_parent = C->valsParent;
-  IndexSpace C_dense_run_0 = C->denseLevelRuns[0];
+
+  int64_t B2Size = runtime->get_index_space_domain(ctx, get_index_space(B2_crd)).hi()[0] + 1;
 
   Point<1> lowerBound = Point<1>(0);
   Point<1> upperBound = Point<1>((gx - 1));
-  auto ioIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
-  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(ioIndexSpace));
-  auto ADomain = runtime->get_index_space_domain(ctx, A_dense_run_0);
-  auto BDomain = runtime->get_index_space_domain(ctx, B_dense_run_0);
-  auto CDomain = runtime->get_index_space_domain(ctx, C_dense_run_0);
-  DomainPointColoring AColoring = DomainPointColoring();
-  DomainPointColoring BColoring = DomainPointColoring();
-  DomainPointColoring CColoring = DomainPointColoring();
+  auto koIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
+  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(koIndexSpace));
+  DomainT<1> B2_crd_domain = runtime->get_index_space_domain(ctx, B2_crd.get_index_space());
+  DomainPointColoring B2_crd_coloring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
-    int32_t io = (*itr)[0];
-    Point<2> AStart = Point<2>((io * ((B1_dimension + (gx - 1)) / gx) + 0 / gx), (0 / gx));
-    Point<2> AEnd = Point<2>(TACO_MIN((io * ((B1_dimension + (gx - 1)) / gx) + ((B1_dimension + (gx - 1)) / gx - 1)), ADomain.hi()[0]), TACO_MIN(((gx - 1) * ((C2_dimension + (gx - 1)) / gx) + ((C2_dimension + (gx - 1)) / gx - 1)), ADomain.hi()[1]));
-    Rect<2> ARect = Rect<2>(AStart, AEnd);
-    if (!ADomain.contains(ARect.lo) || !ADomain.contains(ARect.hi)) {
-      ARect = ARect.make_empty();
+    int32_t ko = (*itr)[0];
+    Point<1> B2CrdStart = Point<1>((ko * ((B2Size + (gx - 1)) / gx)));
+    Point<1> B2CrdEnd = Point<1>(TACO_MAX((ko * ((B2Size + (gx - 1)) / gx) + ((B2Size + (gx - 1)) / gx - 1)),B2_crd_domain.bounds.hi[0]));
+    Rect<1> B2CrdRect = Rect<1>(B2CrdStart, B2CrdEnd);
+    if (!B2_crd_domain.contains(B2CrdRect.lo) || !B2_crd_domain.contains(B2CrdRect.hi)) {
+      B2CrdRect = B2CrdRect.make_empty();
     }
-    AColoring[(*itr)] = ARect;
-    Point<1> BStart = Point<1>((io * ((B1_dimension + (gx - 1)) / gx) + 0 / gx));
-    Point<1> BEnd = Point<1>(TACO_MIN((io * ((B1_dimension + (gx - 1)) / gx) + ((B1_dimension + (gx - 1)) / gx - 1)), BDomain.hi()[0]));
-    Rect<1> BRect = Rect<1>(BStart, BEnd);
-    if (!BDomain.contains(BRect.lo) || !BDomain.contains(BRect.hi)) {
-      BRect = BRect.make_empty();
-    }
-    BColoring[(*itr)] = BRect;
+    B2_crd_coloring[(*itr)] = B2CrdRect;
   }
-  auto APartition = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto A_vals_partition = copyPartition(ctx, runtime, APartition, get_logical_region(A_vals));
-  auto BPartition = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  LogicalPartition posPartB2 = copyPartition(ctx, runtime, BPartition, B2_pos);
-  LogicalPartition crdPartB2 = runtime->get_logical_partition(ctx, B2_crd_parent, runtime->create_partition_by_image_range(
+  IndexPartition B2_crd_index_part = runtime->create_index_partition(ctx, B2_crd.get_index_space(), domain, B2_crd_coloring, LEGION_COMPUTE_KIND);
+  LogicalPartition B2_crd_part = runtime->get_logical_partition(ctx, B2_crd, B2_crd_index_part);
+  IndexPartition posSparsePartB2 = runtime->create_partition_by_preimage_range(
     ctx,
-    B2_crd.get_index_space(),
-    posPartB2,
+    B2_crd_index_part,
+    B2_pos,
     B2_pos_parent,
     FID_RECT_1,
-    runtime->get_index_partition_color_space_name(ctx, posPartB2.get_index_partition())
-  ));
-  auto B_vals_partition = copyPartition(ctx, runtime, crdPartB2, get_logical_region(B_vals));
-  task_2Args taskArgsRaw;
-  taskArgsRaw.B2_dimension = B2_dimension;
-  taskArgsRaw.C2_dimension = C2_dimension;
-  taskArgsRaw.C_dense_run_0 = C_dense_run_0;
-  taskArgsRaw.gx = gx;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_2Args));
-  IndexLauncher launcher = IndexLauncher(taskID(2), domain, taskArgs, ArgumentMap());
-  launcher.add_region_requirement(RegionRequirement(A_vals_partition, 0, READ_ONLY, EXCLUSIVE, A_vals_parent).add_field(FID_VAL));
-  launcher.add_region_requirement(RegionRequirement(posPartB2, 0, READ_ONLY, EXCLUSIVE, get_logical_region(B2_pos_parent)).add_field(FID_RECT_1));
-  launcher.add_region_requirement(RegionRequirement(crdPartB2, 0, READ_ONLY, EXCLUSIVE, get_logical_region(B2_crd_parent)).add_field(FID_COORD));
-  launcher.add_region_requirement(RegionRequirement(B_vals_partition, 0, READ_ONLY, EXCLUSIVE, B_vals_parent).add_field(FID_VAL));
-  launcher.add_region_requirement(RegionRequirement(get_logical_region(C_vals), READ_ONLY, EXCLUSIVE, C_vals_parent).add_field(FID_VAL));
-  runtime->execute_index_space(ctx, launcher);
-
-
+    runtime->get_index_partition_color_space_name(ctx, B2_crd_index_part)
+  );
+  IndexPartition posIndexPartB2 = densifyPartition(ctx, runtime, get_index_space(B2_pos), posSparsePartB2);
+  LogicalPartition posPartB2 = runtime->get_logical_partition(ctx, B2_pos, posIndexPartB2);
+  LogicalPartition BValsLogicalPart = copyPartition(ctx, runtime, B2_crd_part, B_vals);
+  IndexPartition BDenseRun0Partition = copyPartition(ctx, runtime, posPartB2, B_dense_run_0);
+  IndexPartition ADenseRun0Partition = AffineProjection(0).apply(ctx, runtime, BDenseRun0Partition, A_dense_run_0);
+  auto A_vals_partition = copyPartition(ctx, runtime, ADenseRun0Partition, get_logical_region(A_vals));
   auto computePartitions = new(partitionPackForcomputeLegion);
   computePartitions->APartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
   computePartitions->APartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions->APartition.valsPartition = A_vals_partition;
-  computePartitions->APartition.denseLevelRunPartitions[0] = APartition;
+  computePartitions->APartition.denseLevelRunPartitions[0] = ADenseRun0Partition;
   computePartitions->BPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
   computePartitions->BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions->BPartition.indicesPartitions[1].push_back(posPartB2);
-  computePartitions->BPartition.indicesPartitions[1].push_back(crdPartB2);
-  computePartitions->BPartition.valsPartition = B_vals_partition;
-  computePartitions->BPartition.denseLevelRunPartitions[0] = BPartition;
+  computePartitions->BPartition.indicesPartitions[1].push_back(B2_crd_part);
+  computePartitions->BPartition.valsPartition = BValsLogicalPart;
+  computePartitions->BPartition.denseLevelRunPartitions[0] = BDenseRun0Partition;
   return computePartitions;
 }
 
-void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
   PhysicalRegion A_vals = regions[0];
   LogicalRegion A_vals_parent = regions[0].get_logical_region();
   PhysicalRegion B2_pos = regions[1];
@@ -179,112 +92,69 @@ void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   PhysicalRegion C_vals = regions[4];
   LogicalRegion C_vals_parent = regions[4].get_logical_region();
 
-  task_3Args* args = (task_3Args*)(task->args);
+  int32_t ko = task->index_point[0];
+  task_1Args* args = (task_1Args*)(task->args);
   int32_t A1_dimension = args->A1_dimension;
   int32_t A2_dimension = args->A2_dimension;
-  int32_t B1_dimension = args->B1_dimension;
+  int64_t B2Size = args->B2Size;
   int32_t C1_dimension = args->C1_dimension;
   int32_t C2_dimension = args->C2_dimension;
   int32_t gx = args->gx;
-  int32_t io = args->io;
-  int32_t jo = args->jo;
-  int64_t pointID1 = args->pointID1;
 
   auto B_vals_ro_accessor = createAccessor<AccessorROdouble1>(B_vals, FID_VAL);
   auto C_vals_ro_accessor = createAccessor<AccessorROdouble2>(C_vals, FID_VAL);
-  auto A_vals_rw_accessor = createAccessor<AccessorRWdouble2>(A_vals, FID_VAL);
+  auto A_vals_red_accessor = createAccessor<AccessorReducedouble2>(A_vals, FID_VAL, LEGION_REDOP_SUM_FLOAT64);
   auto B2_pos_accessor = createAccessor<AccessorRORect_1_1>(B2_pos, FID_RECT_1);
   auto B2_crd_accessor = createAccessor<AccessorROint32_t1>(B2_crd, FID_COORD);
 
-  int64_t pointID2 = pointID1 * gx + jo;
-  for (int32_t ii = 0 / gx; ii < ((B1_dimension + (gx - 1)) / gx); ii++) {
-    int32_t i = io * (((B1_dimension - 0) + (gx - 1)) / gx) + ii;
-    if (i >= B1_dimension)
-      continue;
+  DomainT<1> BValsDomain = runtime->get_index_space_domain(ctx, get_index_space(B_vals));
+  if (BValsDomain.empty())
+    return ;
 
-    if (i >= (io + 1) * ((B1_dimension + (gx - 1)) / gx - 0 / gx))
-      continue;
-
-    int64_t pointID3 = pointID2 * ((B1_dimension + (gx - 1)) / gx) + ii;
-    int32_t iA = 0 * A1_dimension + i;
-    int32_t iB = 0 * B1_dimension + i;
-    for (int32_t ji = 0 / gx; ji < ((C2_dimension + (gx - 1)) / gx); ji++) {
-      int32_t j = jo * (((C2_dimension - 0) + (gx - 1)) / gx) + ji;
-      if (j >= C2_dimension)
+  DomainT<1> B2PosDomain = runtime->get_index_space_domain(ctx, get_index_space(B2_pos));
+  DomainT<1> B2CrdDomain = runtime->get_index_space_domain(ctx, get_index_space(B2_crd));
+  int32_t pB2_begin = B2PosDomain.bounds.lo;
+  int32_t pB2_end = B2PosDomain.bounds.hi;
+  int64_t pointID1 = ko;
+  #pragma omp parallel for schedule(static)
+  for (int32_t iio = 0; iio < (((B2Size + (gx - 1)) / gx + 2047) / 2048); iio++) {
+    int64_t pointID2 = pointID1 * (((B2Size + (gx - 1)) / gx + 2047) / 2048) + iio;
+    int32_t ki = iio * 2048;
+    int32_t kposB = ko * ((B2Size + (gx - 1)) / gx) + ki;
+    int32_t i_pos = taco_binarySearchBefore(B2_pos_accessor, pB2_begin, pB2_end, kposB);
+    int32_t i = i_pos;
+    for (int32_t iii = 0; iii < 2048; iii++) {
+      int32_t ki = iio * 2048 + iii;
+      int32_t kposB = ko * ((B2Size + (gx - 1)) / gx) + ki;
+      if (kposB >= (ko + 1) * ((B2Size + (gx - 1)) / gx))
         continue;
 
-      if (j >= (jo + 1) * ((C2_dimension + (gx - 1)) / gx - 0 / gx))
+      if (kposB >= B2Size)
         continue;
 
-      int64_t pointID4 = pointID3 * ((C2_dimension + (gx - 1)) / gx) + ji;
-      int32_t jA = iA * A2_dimension + j;
-      for (int32_t kB = B2_pos_accessor[Point<1>(i)].lo; kB < (B2_pos_accessor[Point<1>(i)].hi + 1); kB++) {
-        int32_t k = B2_crd_accessor[(kB * 1)];
-        int32_t kC = 0 * C1_dimension + k;
+      int32_t f = B2_crd_accessor[kposB];
+      int32_t k = f;
+      while (!(B2_pos_accessor[i_pos].contains(kposB))) {
+        i_pos = i_pos + 1;
+        i = i_pos;
+      }
+      int32_t iA = 0 * A1_dimension + i;
+      int32_t kC = 0 * C1_dimension + k;
+      for (int32_t j = 0; j < C2_dimension; j++) {
+        int64_t pointID3 = pointID2 * C2_dimension + j;
+        int32_t jA = iA * A2_dimension + j;
         int32_t jC = kC * C2_dimension + j;
-        A_vals_rw_accessor[Point<2>(i, j)] = A_vals_rw_accessor[Point<2>(i, j)] + B_vals_ro_accessor[Point<1>(kB)] * C_vals_ro_accessor[Point<2>(k, j)];
+        A_vals_red_accessor[Point<2>(i, j)] <<= B_vals_ro_accessor[Point<1>(kposB)] * C_vals_ro_accessor[Point<2>(k, j)];
       }
     }
   }
-}
-
-void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
-  PhysicalRegion A_vals = regions[0];
-  LogicalRegion A_vals_parent = regions[0].get_logical_region();
-  PhysicalRegion B2_pos = regions[1];
-  LogicalRegion B2_pos_parent = regions[1].get_logical_region();
-  PhysicalRegion B2_crd = regions[2];
-  LogicalRegion B2_crd_parent = regions[2].get_logical_region();
-  PhysicalRegion B_vals = regions[3];
-  LogicalRegion B_vals_parent = regions[3].get_logical_region();
-  PhysicalRegion C_vals = regions[4];
-  LogicalRegion C_vals_parent = regions[4].get_logical_region();
-
-  int32_t io = task->index_point[0];
-  task_4Args* args = (task_4Args*)(task->args);
-  int32_t A1_dimension = args->A1_dimension;
-  int32_t A2_dimension = args->A2_dimension;
-  int32_t B1_dimension = args->B1_dimension;
-  int32_t C1_dimension = args->C1_dimension;
-  int32_t C2_dimension = args->C2_dimension;
-  int32_t gx = args->gx;
-
-
-  int64_t pointID1 = io;
-  Point<1> lowerBound = Point<1>(0);
-  Point<1> upperBound = Point<1>((gx - 1));
-  auto joIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
-  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(joIndexSpace));
-  for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
-    int32_t jo = (*itr);
-    task_3Args taskArgsRaw;
-    taskArgsRaw.A1_dimension = A1_dimension;
-    taskArgsRaw.A2_dimension = A2_dimension;
-    taskArgsRaw.B1_dimension = B1_dimension;
-    taskArgsRaw.C1_dimension = C1_dimension;
-    taskArgsRaw.C2_dimension = C2_dimension;
-    taskArgsRaw.gx = gx;
-    taskArgsRaw.io = io;
-    taskArgsRaw.jo = jo;
-    taskArgsRaw.pointID1 = pointID1;
-    TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_3Args));
-    TaskLauncher launcher = TaskLauncher(taskID(3), taskArgs);
-    launcher.add_region_requirement(RegionRequirement(get_logical_region(A_vals), READ_WRITE, EXCLUSIVE, A_vals_parent).add_field(FID_VAL));
-    launcher.add_region_requirement(RegionRequirement(get_logical_region(B2_pos), READ_ONLY, EXCLUSIVE, B2_pos_parent).add_field(FID_RECT_1));
-    launcher.add_region_requirement(RegionRequirement(get_logical_region(B2_crd), READ_ONLY, EXCLUSIVE, B2_crd_parent).add_field(FID_COORD));
-    launcher.add_region_requirement(RegionRequirement(get_logical_region(B_vals), READ_ONLY, EXCLUSIVE, B_vals_parent).add_field(FID_VAL));
-    launcher.add_region_requirement(RegionRequirement(get_logical_region(runtime->get_logical_subregion_by_color(ctx, runtime->get_logical_partition_by_color(ctx, get_logical_region(C_vals), pointID1), jo)), READ_ONLY, EXCLUSIVE, C_vals_parent).add_field(FID_VAL));
-    launcher.tag = launcher.tag | TACOMapper::BACKPRESSURE_TASK;
-    runtime->execute_task(ctx, launcher);
-  }
-
 }
 
 void computeLegion(Context ctx, Runtime* runtime, LegionTensor* A, LegionTensor* B, LegionTensor* C, partitionPackForcomputeLegion* partitionPack, int32_t gx) {
   int A1_dimension = A->dims[0];
   int A2_dimension = A->dims[1];
   auto A_vals_parent = A->valsParent;
-  int B1_dimension = B->dims[0];
+  RegionWrapper B2_crd = B->indices[1][1];
   auto B2_pos_parent = B->indicesParents[1][0];
   auto B2_crd_parent = B->indicesParents[1][1];
   auto B_vals_parent = B->valsParent;
@@ -293,20 +163,22 @@ void computeLegion(Context ctx, Runtime* runtime, LegionTensor* A, LegionTensor*
   RegionWrapper C_vals = C->vals;
   auto C_vals_parent = C->valsParent;
 
+  int64_t B2Size = runtime->get_index_space_domain(ctx, get_index_space(B2_crd)).hi()[0] + 1;
+
   Point<1> lowerBound = Point<1>(0);
   Point<1> upperBound = Point<1>((gx - 1));
-  auto ioIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
-  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(ioIndexSpace));
-  task_4Args taskArgsRaw;
+  auto koIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
+  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(koIndexSpace));
+  task_1Args taskArgsRaw;
   taskArgsRaw.A1_dimension = A1_dimension;
   taskArgsRaw.A2_dimension = A2_dimension;
-  taskArgsRaw.B1_dimension = B1_dimension;
+  taskArgsRaw.B2Size = B2Size;
   taskArgsRaw.C1_dimension = C1_dimension;
   taskArgsRaw.C2_dimension = C2_dimension;
   taskArgsRaw.gx = gx;
-  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_4Args));
-  IndexLauncher launcher = IndexLauncher(taskID(4), domain, taskArgs, ArgumentMap());
-  launcher.add_region_requirement(RegionRequirement(partitionPack->APartition.valsPartition, 0, READ_WRITE, EXCLUSIVE, A_vals_parent).add_field(FID_VAL));
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_1Args));
+  IndexLauncher launcher = IndexLauncher(taskID(1), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(RegionRequirement(partitionPack->APartition.valsPartition, 0, LEGION_REDOP_SUM_FLOAT64, LEGION_SIMULTANEOUS, A_vals_parent).add_field(FID_VAL));
   launcher.add_region_requirement(RegionRequirement(partitionPack->BPartition.indicesPartitions[1][0], 0, READ_ONLY, EXCLUSIVE, get_logical_region(B2_pos_parent)).add_field(FID_RECT_1));
   launcher.add_region_requirement(RegionRequirement(partitionPack->BPartition.indicesPartitions[1][1], 0, READ_ONLY, EXCLUSIVE, get_logical_region(B2_crd_parent)).add_field(FID_COORD));
   launcher.add_region_requirement(RegionRequirement(partitionPack->BPartition.valsPartition, 0, READ_ONLY, EXCLUSIVE, B_vals_parent).add_field(FID_VAL));
@@ -316,21 +188,9 @@ void computeLegion(Context ctx, Runtime* runtime, LegionTensor* A, LegionTensor*
 }
 void registerTacoTasks() {
   {
-    TaskVariantRegistrar registrar(taskID(2), "task_2");
-    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
-    registrar.set_inner();
-    Runtime::preregister_task_variant<task_2>(registrar, "task_2");
-  }
-  {
-    TaskVariantRegistrar registrar(taskID(3), "task_3");
+    TaskVariantRegistrar registrar(taskID(1), "task_1");
     registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
     registrar.set_leaf();
-    Runtime::preregister_task_variant<task_3>(registrar, "task_3");
-  }
-  {
-    TaskVariantRegistrar registrar(taskID(4), "task_4");
-    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
-    registrar.set_inner();
-    Runtime::preregister_task_variant<task_4>(registrar, "task_4");
+    Runtime::preregister_task_variant<task_1>(registrar, "task_1");
   }
 }

--- a/legion/spmv/taco-generated.cpp
+++ b/legion/spmv/taco-generated.cpp
@@ -1,12 +1,15 @@
 #include "taco_legion_header.h"
 #include "taco_mapper.h"
 #define TACO_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))
+#define TACO_MAX(_a,_b) ((_a) < (_b) ? (_b) : (_a))
 using namespace Legion;
 typedef FieldAccessor<READ_ONLY,int32_t,1,coord_t,Realm::AffineAccessor<int32_t,1,coord_t>> AccessorROint32_t1;
 typedef FieldAccessor<READ_ONLY,double,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorROdouble1;
 typedef FieldAccessor<READ_WRITE,double,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorRWdouble1;
+typedef ReductionAccessor<SumReduction<double>,true,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorReducedouble1;
 typedef ReductionAccessor<SumReduction<double>,false,1,coord_t,Realm::AffineAccessor<double,1,coord_t>> AccessorReduceNonExcldouble1;
 typedef FieldAccessor<READ_ONLY,Rect<1>,1,coord_t,Realm::AffineAccessor<Rect<1>,1,coord_t>> AccessorRORect_1_1;
+typedef FieldAccessor<READ_ONLY,double,2,coord_t,Realm::AffineAccessor<double,2,coord_t>> AccessorROdouble2;
 
 struct partitionPackForcomputeLegionRowSplit {
   LegionTensorPartition aPartition;
@@ -40,6 +43,16 @@ struct task_3Args {
   int32_t c1_dimension;
   int32_t pieces;
 };
+struct partitionPackForcomputeLegionSparseDensePosParallelize {
+  LegionTensorPartition BPartition;
+};
+
+struct task_4Args {
+  int32_t B2_dimension;
+  int32_t a1_dimension;
+  int32_t c1_dimension;
+  int32_t pieces;
+};
 
 partitionPackForcomputeLegionRowSplit* partitionForcomputeLegionRowSplit(Context ctx, Runtime* runtime, LegionTensor* a, LegionTensor* B, LegionTensor* c, int32_t pieces) {
   RegionWrapper a_vals = a->vals;
@@ -66,14 +79,14 @@ partitionPackForcomputeLegionRowSplit* partitionForcomputeLegionRowSplit(Context
   DomainPointColoring cColoring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t io = (*itr)[0];
-    Point<1> BStart = Point<1>((io * ((B1_dimension + (pieces - 1)) / pieces) + 0 / pieces));
+    Point<1> BStart = Point<1>((io * ((B1_dimension + (pieces - 1)) / pieces)));
     Point<1> BEnd = Point<1>(TACO_MIN((io * ((B1_dimension + (pieces - 1)) / pieces) + ((B1_dimension + (pieces - 1)) / pieces - 1)), BDomain.hi()[0]));
     Rect<1> BRect = Rect<1>(BStart, BEnd);
     if (!BDomain.contains(BRect.lo) || !BDomain.contains(BRect.hi)) {
       BRect = BRect.make_empty();
     }
     BColoring[(*itr)] = BRect;
-    Point<1> aStart = Point<1>((io * ((B1_dimension + (pieces - 1)) / pieces) + 0 / pieces));
+    Point<1> aStart = Point<1>((io * ((B1_dimension + (pieces - 1)) / pieces)));
     Point<1> aEnd = Point<1>(TACO_MIN((io * ((B1_dimension + (pieces - 1)) / pieces) + ((B1_dimension + (pieces - 1)) / pieces - 1)), aDomain.hi()[0]));
     Rect<1> aRect = Rect<1>(aStart, aEnd);
     if (!aDomain.contains(aRect.lo) || !aDomain.contains(aRect.hi)) {
@@ -81,8 +94,8 @@ partitionPackForcomputeLegionRowSplit* partitionForcomputeLegionRowSplit(Context
     }
     aColoring[(*itr)] = aRect;
   }
-  auto BPartition = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  LogicalPartition posPartB2 = copyPartition(ctx, runtime, BPartition, B2_pos);
+  auto B_dense_run_0_Partition = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  LogicalPartition posPartB2 = copyPartition(ctx, runtime, B_dense_run_0_Partition, B2_pos);
   LogicalPartition crdPartB2 = runtime->get_logical_partition(ctx, B2_crd, runtime->create_partition_by_image_range(
     ctx,
     B2_crd.get_index_space(),
@@ -92,19 +105,19 @@ partitionPackForcomputeLegionRowSplit* partitionForcomputeLegionRowSplit(Context
     runtime->get_index_partition_color_space_name(ctx, posPartB2.get_index_partition())
   ));
   auto B_vals_partition = copyPartition(ctx, runtime, crdPartB2, get_logical_region(B_vals));
-  auto aPartition = runtime->create_index_partition(ctx, a_dense_run_0, domain, aColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto a_vals_partition = copyPartition(ctx, runtime, aPartition, get_logical_region(a_vals));
+  auto a_dense_run_0_Partition = runtime->create_index_partition(ctx, a_dense_run_0, domain, aColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto a_vals_partition = copyPartition(ctx, runtime, a_dense_run_0_Partition, get_logical_region(a_vals));
   auto computePartitions = new(partitionPackForcomputeLegionRowSplit);
   computePartitions->aPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(1);
   computePartitions->aPartition.denseLevelRunPartitions = std::vector<IndexPartition>(1);
   computePartitions->aPartition.valsPartition = a_vals_partition;
-  computePartitions->aPartition.denseLevelRunPartitions[0] = aPartition;
+  computePartitions->aPartition.denseLevelRunPartitions[0] = a_dense_run_0_Partition;
   computePartitions->BPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
   computePartitions->BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions->BPartition.indicesPartitions[1].push_back(posPartB2);
   computePartitions->BPartition.indicesPartitions[1].push_back(crdPartB2);
   computePartitions->BPartition.valsPartition = B_vals_partition;
-  computePartitions->BPartition.denseLevelRunPartitions[0] = BPartition;
+  computePartitions->BPartition.denseLevelRunPartitions[0] = B_dense_run_0_Partition;
   return computePartitions;
 }
 
@@ -127,20 +140,20 @@ void task_1(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   int32_t c1_dimension = args->c1_dimension;
   int32_t pieces = args->pieces;
 
-  auto B_vals_ro_accessor = createAccessor<AccessorROdouble1>(B_vals, FID_VAL);
   auto c_vals_ro_accessor = createAccessor<AccessorROdouble1>(c_vals, FID_VAL);
+  auto B_vals_ro_accessor = createAccessor<AccessorROdouble1>(B_vals, FID_VAL);
   auto a_vals_rw_accessor = createAccessor<AccessorRWdouble1>(a_vals, FID_VAL);
   auto B2_pos_accessor = createAccessor<AccessorRORect_1_1>(B2_pos, FID_RECT_1);
   auto B2_crd_accessor = createAccessor<AccessorROint32_t1>(B2_crd, FID_COORD);
 
   int64_t pointID1 = io;
   #pragma omp parallel for schedule(static)
-  for (int32_t ii = 0 / pieces; ii < ((B1_dimension + (pieces - 1)) / pieces); ii++) {
+  for (int32_t ii = 0; ii < ((B1_dimension + (pieces - 1)) / pieces); ii++) {
     int32_t i = io * ((B1_dimension + (pieces - 1)) / pieces) + ii;
     if (i >= B1_dimension)
       continue;
 
-    if (i >= (io + 1) * ((B1_dimension + (pieces - 1)) / pieces - 0 / pieces))
+    if (i >= (io + 1) * ((B1_dimension + (pieces - 1)) / pieces))
       continue;
 
     int64_t pointID2 = pointID1 * ((B1_dimension + (pieces - 1)) / pieces) + ii;
@@ -203,43 +216,43 @@ partitionPackForcomputeLegionPosSplit* partitionForcomputeLegionPosSplit(Context
   Point<1> upperBound = Point<1>((pieces - 1));
   auto fposoIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
   DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(fposoIndexSpace));
-  auto BValsDomain = runtime->get_index_space_domain(ctx, get_index_space(B_vals));
-  auto BValsColoring = DomainPointColoring();
+  DomainT<1> B2_crd_domain = runtime->get_index_space_domain(ctx, B2_crd.get_index_space());
+  DomainPointColoring B2_crd_coloring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t fposo = (*itr)[0];
-    Point<1> BStart = Point<1>((fposo * ((B2Size + (pieces - 1)) / pieces) + 0 / pieces));
-    Point<1> BEnd = Point<1>(TACO_MIN((fposo * ((B2Size + (pieces - 1)) / pieces) + ((B2Size + (pieces - 1)) / pieces - 1)), BValsDomain.hi()[0]));
-    Rect<1> BRect = Rect<1>(BStart, BEnd);
-    if (!BValsDomain.contains(BRect.lo) || !BValsDomain.contains(BRect.hi)) {
-      BRect = BRect.make_empty();
+    Point<1> B2CrdStart = Point<1>((fposo * ((B2Size + (pieces - 1)) / pieces)));
+    Point<1> B2CrdEnd = Point<1>(TACO_MIN((fposo * ((B2Size + (pieces - 1)) / pieces) + ((B2Size + (pieces - 1)) / pieces - 1)), B2_crd_domain.bounds.hi[0]));
+    Rect<1> B2CrdRect = Rect<1>(B2CrdStart, B2CrdEnd);
+    if (!B2_crd_domain.contains(B2CrdRect.lo) || !B2_crd_domain.contains(B2CrdRect.hi)) {
+      B2CrdRect = B2CrdRect.make_empty();
     }
-    BValsColoring[(*itr)] = BRect;
+    B2_crd_coloring[(*itr)] = B2CrdRect;
   }
-  IndexPartition BValsIndexPart = runtime->create_index_partition(ctx, get_index_space(B_vals), domain, BValsColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  LogicalPartition BValsLogicalPart = runtime->get_logical_partition(ctx, B_vals, BValsIndexPart);
-  LogicalPartition crdPartB2 = copyPartition(ctx, runtime, BValsLogicalPart, B2_crd);
+  IndexPartition B2_crd_index_part = runtime->create_index_partition(ctx, B2_crd.get_index_space(), domain, B2_crd_coloring, LEGION_COMPUTE_KIND);
+  LogicalPartition B2_crd_part = runtime->get_logical_partition(ctx, B2_crd, B2_crd_index_part);
   IndexPartition posSparsePartB2 = runtime->create_partition_by_preimage_range(
     ctx,
-    crdPartB2.get_index_partition(),
+    B2_crd_index_part,
     B2_pos,
     B2_pos_parent,
     FID_RECT_1,
-    runtime->get_index_partition_color_space_name(ctx, crdPartB2.get_index_partition())
+    runtime->get_index_partition_color_space_name(ctx, B2_crd_index_part)
   );
   IndexPartition posIndexPartB2 = densifyPartition(ctx, runtime, get_index_space(B2_pos), posSparsePartB2);
   LogicalPartition posPartB2 = runtime->get_logical_partition(ctx, B2_pos, posIndexPartB2);
+  LogicalPartition BValsLogicalPart = copyPartition(ctx, runtime, B2_crd_part, B_vals);
   IndexPartition BDenseRun0Partition = copyPartition(ctx, runtime, posPartB2, B_dense_run_0);
-  LogicalPartition aValsLogicalPart = copyPartition(ctx, runtime, posPartB2, a_vals);
-  IndexPartition aDenseRun0Partition = copyPartition(ctx, runtime, aValsLogicalPart, a_dense_run_0);
+  IndexPartition aDenseRun0Partition = AffineProjection(0).apply(ctx, runtime, BDenseRun0Partition, a_dense_run_0);
+  auto a_vals_partition = copyPartition(ctx, runtime, aDenseRun0Partition, get_logical_region(a_vals));
   auto computePartitions = new(partitionPackForcomputeLegionPosSplit);
   computePartitions->aPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(1);
   computePartitions->aPartition.denseLevelRunPartitions = std::vector<IndexPartition>(1);
-  computePartitions->aPartition.valsPartition = aValsLogicalPart;
+  computePartitions->aPartition.valsPartition = a_vals_partition;
   computePartitions->aPartition.denseLevelRunPartitions[0] = aDenseRun0Partition;
   computePartitions->BPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
   computePartitions->BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions->BPartition.indicesPartitions[1].push_back(posPartB2);
-  computePartitions->BPartition.indicesPartitions[1].push_back(crdPartB2);
+  computePartitions->BPartition.indicesPartitions[1].push_back(B2_crd_part);
   computePartitions->BPartition.valsPartition = BValsLogicalPart;
   computePartitions->BPartition.denseLevelRunPartitions[0] = BDenseRun0Partition;
   return computePartitions;
@@ -280,16 +293,16 @@ void task_2(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   int32_t pB2_end = B2PosDomain.bounds.hi;
   int64_t pointID1 = fposo;
   #pragma omp parallel for schedule(static)
-  for (int32_t fposio = 0; fposio < ((((B2Size + (pieces - 1)) / pieces - 0 / pieces) + 2047) / 2048); fposio++) {
-    int64_t pointID2 = pointID1 * ((((B2Size + (pieces - 1)) / pieces - 0 / pieces) + 2047) / 2048) + fposio;
-    int32_t fposi = fposio * 2048 + 0 / pieces;
+  for (int32_t fposio = 0; fposio < (((B2Size + (pieces - 1)) / pieces + 2047) / 2048); fposio++) {
+    int64_t pointID2 = pointID1 * (((B2Size + (pieces - 1)) / pieces + 2047) / 2048) + fposio;
+    int32_t fposi = fposio * 2048;
     int32_t fposB = fposo * ((B2Size + (pieces - 1)) / pieces) + fposi;
     int32_t i_pos = taco_binarySearchBefore(B2_pos_accessor, pB2_begin, pB2_end, fposB);
     int32_t i = i_pos;
     for (int32_t fposii = 0; fposii < 2048; fposii++) {
-      int32_t fposi = (fposio * 2048 + fposii) + 0 / pieces;
+      int32_t fposi = fposio * 2048 + fposii;
       int32_t fposB = fposo * ((B2Size + (pieces - 1)) / pieces) + fposi;
-      if (fposB >= (fposo + 1) * ((B2Size + (pieces - 1)) / pieces - 0 / pieces))
+      if (fposB >= (fposo + 1) * ((B2Size + (pieces - 1)) / pieces))
         continue;
 
       if (fposB >= B2Size)
@@ -357,31 +370,31 @@ partitionPackForcomputeLegionPosSplitDCSR* partitionForcomputeLegionPosSplitDCSR
   Point<1> upperBound = Point<1>((pieces - 1));
   auto fposoIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
   DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(fposoIndexSpace));
-  auto BValsDomain = runtime->get_index_space_domain(ctx, get_index_space(B_vals));
-  auto BValsColoring = DomainPointColoring();
+  DomainT<1> B2_crd_domain = runtime->get_index_space_domain(ctx, B2_crd.get_index_space());
+  DomainPointColoring B2_crd_coloring = DomainPointColoring();
   for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
     int32_t fposo = (*itr)[0];
-    Point<1> BStart = Point<1>((fposo * ((B2Size + (pieces - 1)) / pieces) + 0 / pieces));
-    Point<1> BEnd = Point<1>(TACO_MIN((fposo * ((B2Size + (pieces - 1)) / pieces) + ((B2Size + (pieces - 1)) / pieces - 1)), BValsDomain.hi()[0]));
-    Rect<1> BRect = Rect<1>(BStart, BEnd);
-    if (!BValsDomain.contains(BRect.lo) || !BValsDomain.contains(BRect.hi)) {
-      BRect = BRect.make_empty();
+    Point<1> B2CrdStart = Point<1>((fposo * ((B2Size + (pieces - 1)) / pieces)));
+    Point<1> B2CrdEnd = Point<1>(TACO_MIN((fposo * ((B2Size + (pieces - 1)) / pieces) + ((B2Size + (pieces - 1)) / pieces - 1)), B2_crd_domain.bounds.hi[0]));
+    Rect<1> B2CrdRect = Rect<1>(B2CrdStart, B2CrdEnd);
+    if (!B2_crd_domain.contains(B2CrdRect.lo) || !B2_crd_domain.contains(B2CrdRect.hi)) {
+      B2CrdRect = B2CrdRect.make_empty();
     }
-    BValsColoring[(*itr)] = BRect;
+    B2_crd_coloring[(*itr)] = B2CrdRect;
   }
-  IndexPartition BValsIndexPart = runtime->create_index_partition(ctx, get_index_space(B_vals), domain, BValsColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  LogicalPartition BValsLogicalPart = runtime->get_logical_partition(ctx, B_vals, BValsIndexPart);
-  LogicalPartition crdPartB2 = copyPartition(ctx, runtime, BValsLogicalPart, B2_crd);
+  IndexPartition B2_crd_index_part = runtime->create_index_partition(ctx, B2_crd.get_index_space(), domain, B2_crd_coloring, LEGION_COMPUTE_KIND);
+  LogicalPartition B2_crd_part = runtime->get_logical_partition(ctx, B2_crd, B2_crd_index_part);
   IndexPartition posSparsePartB2 = runtime->create_partition_by_preimage_range(
     ctx,
-    crdPartB2.get_index_partition(),
+    B2_crd_index_part,
     B2_pos,
     B2_pos_parent,
     FID_RECT_1,
-    runtime->get_index_partition_color_space_name(ctx, crdPartB2.get_index_partition())
+    runtime->get_index_partition_color_space_name(ctx, B2_crd_index_part)
   );
   IndexPartition posIndexPartB2 = densifyPartition(ctx, runtime, get_index_space(B2_pos), posSparsePartB2);
   LogicalPartition posPartB2 = runtime->get_logical_partition(ctx, B2_pos, posIndexPartB2);
+  LogicalPartition BValsLogicalPart = copyPartition(ctx, runtime, B2_crd_part, B_vals);
   LogicalPartition crdPartB1 = copyPartition(ctx, runtime, posPartB2, B1_crd);
   IndexPartition posSparsePartB1 = runtime->create_partition_by_preimage_range(
     ctx,
@@ -399,7 +412,7 @@ partitionPackForcomputeLegionPosSplitDCSR* partitionForcomputeLegionPosSplitDCSR
   computePartitions->BPartition.indicesPartitions[0].push_back(posPartB1);
   computePartitions->BPartition.indicesPartitions[0].push_back(crdPartB1);
   computePartitions->BPartition.indicesPartitions[1].push_back(posPartB2);
-  computePartitions->BPartition.indicesPartitions[1].push_back(crdPartB2);
+  computePartitions->BPartition.indicesPartitions[1].push_back(B2_crd_part);
   computePartitions->BPartition.valsPartition = BValsLogicalPart;
   return computePartitions;
 }
@@ -427,8 +440,8 @@ void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   int32_t c1_dimension = args->c1_dimension;
   int32_t pieces = args->pieces;
 
-  auto B_vals_ro_accessor = createAccessor<AccessorROdouble1>(B_vals, FID_VAL);
   auto c_vals_ro_accessor = createAccessor<AccessorROdouble1>(c_vals, FID_VAL);
+  auto B_vals_ro_accessor = createAccessor<AccessorROdouble1>(B_vals, FID_VAL);
   auto a_vals_red_accessor_non_excl = createAccessor<AccessorReduceNonExcldouble1>(a_vals, FID_VAL, LEGION_REDOP_SUM_FLOAT64);
   auto B1_crd_accessor = createAccessor<AccessorROint32_t1>(B1_crd, FID_COORD);
   auto B2_pos_accessor = createAccessor<AccessorRORect_1_1>(B2_pos, FID_RECT_1);
@@ -444,16 +457,16 @@ void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   int32_t pB2_end = B2PosDomain.bounds.hi;
   int64_t pointID1 = fposo;
   #pragma omp parallel for schedule(static)
-  for (int32_t fposio = 0; fposio < ((((B2Size + (pieces - 1)) / pieces - 0 / pieces) + 2047) / 2048); fposio++) {
-    int64_t pointID2 = pointID1 * ((((B2Size + (pieces - 1)) / pieces - 0 / pieces) + 2047) / 2048) + fposio;
-    int32_t fposi = fposio * 2048 + 0 / pieces;
+  for (int32_t fposio = 0; fposio < (((B2Size + (pieces - 1)) / pieces + 2047) / 2048); fposio++) {
+    int64_t pointID2 = pointID1 * (((B2Size + (pieces - 1)) / pieces + 2047) / 2048) + fposio;
+    int32_t fposi = fposio * 2048;
     int32_t fposB = fposo * ((B2Size + (pieces - 1)) / pieces) + fposi;
     int32_t i_pos = taco_binarySearchBefore(B2_pos_accessor, pB2_begin, pB2_end, fposB);
     int32_t i = B1_crd_accessor[i_pos];
     for (int32_t fposii = 0; fposii < 2048; fposii++) {
-      int32_t fposi = (fposio * 2048 + fposii) + 0 / pieces;
+      int32_t fposi = fposio * 2048 + fposii;
       int32_t fposB = fposo * ((B2Size + (pieces - 1)) / pieces) + fposi;
-      if (fposB >= (fposo + 1) * ((B2Size + (pieces - 1)) / pieces - 0 / pieces))
+      if (fposB >= (fposo + 1) * ((B2Size + (pieces - 1)) / pieces))
         continue;
 
       if (fposB >= B2Size)
@@ -520,6 +533,155 @@ void computeLegionPosSplitDCSR(Context ctx, Runtime* runtime, LegionTensor* a, L
   runtime->execute_index_space(ctx, launcher);
 
 }
+
+partitionPackForcomputeLegionSparseDensePosParallelize* partitionForcomputeLegionSparseDensePosParallelize(Context ctx, Runtime* runtime, LegionTensor* a, LegionTensor* B, LegionTensor* c, int32_t pieces) {
+  RegionWrapper B1_pos = B->indices[0][0];
+  RegionWrapper B1_crd = B->indices[0][1];
+  auto B1_pos_parent = B->indicesParents[0][0];
+  auto B1_crd_parent = B->indicesParents[0][1];
+  RegionWrapper B_vals = B->vals;
+  auto B_vals_parent = B->valsParent;
+  auto B_vals_ro_accessor = createAccessor<AccessorROdouble2>(B_vals, FID_VAL);
+  auto B1_pos_accessor = createAccessor<AccessorRORect_1_1>(B1_pos, FID_RECT_1);
+  auto B1_crd_accessor = createAccessor<AccessorROint32_t1>(B1_crd, FID_COORD);
+  RegionWrapper c_vals = c->vals;
+  auto c_vals_parent = c->valsParent;
+  auto c_vals_ro_accessor = createAccessor<AccessorROdouble1>(c_vals, FID_VAL);
+
+  B1_pos = legionMalloc(ctx, runtime, B1_pos, B1_pos_parent, FID_RECT_1);
+  B1_pos_accessor = createAccessor<AccessorRORect_1_1>(B1_pos, FID_RECT_1);
+  B1_crd = legionMalloc(ctx, runtime, B1_crd, B1_crd_parent, FID_COORD);
+  B1_crd_accessor = createAccessor<AccessorROint32_t1>(B1_crd, FID_COORD);
+  B_vals = legionMalloc(ctx, runtime, B_vals, B_vals_parent, FID_VAL);
+  B_vals_ro_accessor = createAccessor<AccessorROdouble2>(B_vals, FID_VAL);
+  c_vals = legionMalloc(ctx, runtime, c_vals, c_vals_parent, FID_VAL);
+  c_vals_ro_accessor = createAccessor<AccessorROdouble1>(c_vals, FID_VAL);
+
+  int64_t B1Size = runtime->get_index_space_domain(ctx, get_index_space(B1_crd)).hi()[0] + 1;
+
+  Point<1> lowerBound = Point<1>(0);
+  Point<1> upperBound = Point<1>((pieces - 1));
+  auto fposoIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
+  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(fposoIndexSpace));
+  DomainT<1> B1_crd_domain = runtime->get_index_space_domain(ctx, B1_crd.get_index_space());
+  DomainPointColoring B1_crd_coloring = DomainPointColoring();
+  for (PointInDomainIterator<1> itr = PointInDomainIterator<1>(domain); itr.valid(); itr++) {
+    int32_t fposo = (*itr)[0];
+    Point<1> B1CrdStart = Point<1>((fposo * ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces) + B1_pos_accessor[Point<1>(0)].lo));
+    Point<1> B1CrdEnd = Point<1>(TACO_MIN(((fposo * ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces) + ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces - 1)) + B1_pos_accessor[Point<1>(0)].lo), B1_crd_domain.bounds.hi[0]));
+    Rect<1> B1CrdRect = Rect<1>(B1CrdStart, B1CrdEnd);
+    if (!B1_crd_domain.contains(B1CrdRect.lo) || !B1_crd_domain.contains(B1CrdRect.hi)) {
+      B1CrdRect = B1CrdRect.make_empty();
+    }
+    B1_crd_coloring[(*itr)] = B1CrdRect;
+  }
+  IndexPartition B1_crd_index_part = runtime->create_index_partition(ctx, B1_crd.get_index_space(), domain, B1_crd_coloring, LEGION_COMPUTE_KIND);
+  LogicalPartition B1_crd_part = runtime->get_logical_partition(ctx, B1_crd, B1_crd_index_part);
+  IndexPartition posSparsePartB1 = runtime->create_partition_by_preimage_range(
+    ctx,
+    B1_crd_index_part,
+    B1_pos,
+    B1_pos_parent,
+    FID_RECT_1,
+    runtime->get_index_partition_color_space_name(ctx, B1_crd_index_part)
+  );
+  IndexPartition posIndexPartB1 = densifyPartition(ctx, runtime, get_index_space(B1_pos), posSparsePartB1);
+  LogicalPartition posPartB1 = runtime->get_logical_partition(ctx, B1_pos, posIndexPartB1);
+  LogicalPartition BValsLogicalPart = copyPartition(ctx, runtime, B1_crd_part, B_vals);
+  auto computePartitions = new(partitionPackForcomputeLegionSparseDensePosParallelize);
+  computePartitions->BPartition.indicesPartitions = std::vector<std::vector<LogicalPartition>>(2);
+  computePartitions->BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
+  computePartitions->BPartition.indicesPartitions[0].push_back(posPartB1);
+  computePartitions->BPartition.indicesPartitions[0].push_back(B1_crd_part);
+  computePartitions->BPartition.valsPartition = BValsLogicalPart;
+  return computePartitions;
+
+  runtime->unmap_region(ctx, B1_crd);
+  runtime->unmap_region(ctx, B1_pos);
+  runtime->unmap_region(ctx, B_vals);
+  runtime->unmap_region(ctx, c_vals);
+}
+
+void task_4(const Task* task, const std::vector<PhysicalRegion>& regions, Context ctx, Runtime* runtime) {
+  PhysicalRegion a_vals = regions[0];
+  LogicalRegion a_vals_parent = regions[0].get_logical_region();
+  PhysicalRegion B1_pos = regions[1];
+  LogicalRegion B1_pos_parent = regions[1].get_logical_region();
+  PhysicalRegion B1_crd = regions[2];
+  LogicalRegion B1_crd_parent = regions[2].get_logical_region();
+  PhysicalRegion B_vals = regions[3];
+  LogicalRegion B_vals_parent = regions[3].get_logical_region();
+  PhysicalRegion c_vals = regions[4];
+  LogicalRegion c_vals_parent = regions[4].get_logical_region();
+
+  int32_t fposo = task->index_point[0];
+  task_4Args* args = (task_4Args*)(task->args);
+  int32_t B2_dimension = args->B2_dimension;
+  int32_t a1_dimension = args->a1_dimension;
+  int32_t c1_dimension = args->c1_dimension;
+  int32_t pieces = args->pieces;
+
+  auto c_vals_ro_accessor = createAccessor<AccessorROdouble1>(c_vals, FID_VAL);
+  auto B_vals_ro_accessor = createAccessor<AccessorROdouble2>(B_vals, FID_VAL);
+  auto a_vals_red_accessor = createAccessor<AccessorReducedouble1>(a_vals, FID_VAL, LEGION_REDOP_SUM_FLOAT64);
+  auto B1_pos_accessor = createAccessor<AccessorRORect_1_1>(B1_pos, FID_RECT_1);
+  auto B1_crd_accessor = createAccessor<AccessorROint32_t1>(B1_crd, FID_COORD);
+
+  int64_t pointID1 = fposo;
+  for (int32_t fposi = 0; fposi < ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces); fposi++) {
+    int32_t fposB = (fposo * ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces) + fposi) + B1_pos_accessor[Point<1>(0)].lo;
+    if (fposB >= (fposo + 1) * ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces))
+      continue;
+
+    if (fposB < B1_pos_accessor[Point<1>(0)].lo || fposB >= B1_pos_accessor[Point<1>(0)].hi + 1)
+      continue;
+
+    int32_t i = B1_crd_accessor[fposB];
+    int64_t pointID2 = pointID1 * ((((B1_pos_accessor[Point<1>(0)].hi + 1) - B1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces) + fposi;
+    int32_t ia = 0 * a1_dimension + i;
+    for (int32_t j = 0; j < B2_dimension; j++) {
+      int64_t pointID3 = pointID2 * B2_dimension + j;
+      int32_t jB = fposB * B2_dimension + j;
+      int32_t jc = 0 * c1_dimension + j;
+      a_vals_red_accessor[Point<1>(i)] <<= B_vals_ro_accessor[Point<2>(fposB, j)] * c_vals_ro_accessor[Point<1>(j)];
+    }
+  }
+}
+
+void computeLegionSparseDensePosParallelize(Context ctx, Runtime* runtime, LegionTensor* a, LegionTensor* B, LegionTensor* c, partitionPackForcomputeLegionSparseDensePosParallelize* partitionPack, int32_t pieces) {
+  int a1_dimension = a->dims[0];
+  RegionWrapper a_vals = a->vals;
+  auto a_vals_parent = a->valsParent;
+  int B2_dimension = B->dims[1];
+  RegionWrapper B1_crd = B->indices[0][1];
+  auto B1_pos_parent = B->indicesParents[0][0];
+  auto B1_crd_parent = B->indicesParents[0][1];
+  auto B_vals_parent = B->valsParent;
+  int c1_dimension = c->dims[0];
+  RegionWrapper c_vals = c->vals;
+  auto c_vals_parent = c->valsParent;
+
+  int64_t B1Size = runtime->get_index_space_domain(ctx, get_index_space(B1_crd)).hi()[0] + 1;
+
+  Point<1> lowerBound = Point<1>(0);
+  Point<1> upperBound = Point<1>((pieces - 1));
+  auto fposoIndexSpace = runtime->create_index_space(ctx, Rect<1>(lowerBound, upperBound));
+  DomainT<1> domain = runtime->get_index_space_domain(ctx, IndexSpaceT<1>(fposoIndexSpace));
+  task_4Args taskArgsRaw;
+  taskArgsRaw.B2_dimension = B2_dimension;
+  taskArgsRaw.a1_dimension = a1_dimension;
+  taskArgsRaw.c1_dimension = c1_dimension;
+  taskArgsRaw.pieces = pieces;
+  TaskArgument taskArgs = TaskArgument(&taskArgsRaw, sizeof(task_4Args));
+  IndexLauncher launcher = IndexLauncher(taskID(4), domain, taskArgs, ArgumentMap());
+  launcher.add_region_requirement(RegionRequirement(get_logical_region(a_vals), LEGION_REDOP_SUM_FLOAT64, LEGION_SIMULTANEOUS, a_vals_parent).add_field(FID_VAL));
+  launcher.add_region_requirement(RegionRequirement(partitionPack->BPartition.indicesPartitions[0][0], 0, READ_ONLY, EXCLUSIVE, get_logical_region(B1_pos_parent)).add_field(FID_RECT_1));
+  launcher.add_region_requirement(RegionRequirement(partitionPack->BPartition.indicesPartitions[0][1], 0, READ_ONLY, EXCLUSIVE, get_logical_region(B1_crd_parent)).add_field(FID_COORD));
+  launcher.add_region_requirement(RegionRequirement(partitionPack->BPartition.valsPartition, 0, READ_ONLY, EXCLUSIVE, B_vals_parent).add_field(FID_VAL));
+  launcher.add_region_requirement(RegionRequirement(get_logical_region(c_vals), READ_ONLY, EXCLUSIVE, c_vals_parent).add_field(FID_VAL));
+  runtime->execute_index_space(ctx, launcher);
+
+}
 void registerTacoTasks() {
   {
     TaskVariantRegistrar registrar(taskID(1), "task_1");
@@ -538,5 +700,11 @@ void registerTacoTasks() {
     registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
     registrar.set_leaf();
     Runtime::preregister_task_variant<task_3>(registrar, "task_3");
+  }
+  {
+    TaskVariantRegistrar registrar(taskID(4), "task_4");
+    registrar.add_constraint(ProcessorConstraint(Processor::LOC_PROC));
+    registrar.set_leaf();
+    Runtime::preregister_task_variant<task_4>(registrar, "task_4");
   }
 }

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -3470,6 +3470,21 @@ bool preservesNonZeroStructure(IndexStmt stmt, NonZeroAnalyzerResult& res) {
     return false;
   }
 
+  // If the result tensor is all dense, then it doesn't matter as well.
+  {
+    bool resultAllDense = true;
+    auto formats = resultAccess->getTensorVar().getFormat().getModeFormats();
+    for (size_t i = 0; i < formats.size(); i++) {
+      if (!formats[i].is<DenseModeFormat>()) {
+        resultAllDense = false;
+        break;
+      }
+    }
+    if (resultAllDense) {
+      return false;
+    }
+  }
+
   // Now, there can only be one non-dense tensor in the LHS.
   std::vector<Access> sparseRHSTensors;
   match(stmt, std::function<void(const AssignmentNode*, Matcher*)>([&](const AssignmentNode* node, Matcher* m) {

--- a/src/ir/ir.cpp
+++ b/src/ir/ir.cpp
@@ -1318,6 +1318,9 @@ ir::Expr ctx = ir::Symbol::make("ctx");
 ir::Expr runtime = ir::Symbol::make("runtime");
 ir::Expr AffineProjectionBot = ir::Symbol::make("AffineProjection::BOT");
 ir::Expr GPUFBMem = ir::Symbol::make("Legion::Memory::Kind::GPU_FB_MEM");
+ir::Expr disjointPart = ir::Symbol::make("LEGION_DISJOINT_COMPLETE_KIND");
+ir::Expr aliasedPart = ir::Symbol::make("LEGION_ALIASED_COMPLETE_KIND");
+ir::Expr computePart = ir::Symbol::make("LEGION_COMPUTE_KIND");
 
 } // namespace ir
 } // namespace taco

--- a/src/lower/iterator.cpp
+++ b/src/lower/iterator.cpp
@@ -488,11 +488,24 @@ void Iterator::setIndexSetIterator(Iterator iter) {
   this->content->indexSetIterator = iter;
 }
 
+ir::Stmt Iterator::getInitializePosColoring() const {
+  taco_iassert(this->defined());
+  return getMode().getModeFormat().impl->getInitializePosColoring(getMode());
+}
 
-ModeFunction Iterator::getCreateInitialPartition() const {
-  // TODO (rohany): This has to do some work to create an initial partition from the
-  //  dense runs in the format.
-  return getMode().getModeFormat().impl->getCreateInitialPartition(getMode());
+ir::Stmt Iterator::getCreatePosColoringEntry(ir::Expr domainPoint, ir::Expr lowerBound, ir::Expr upperBound) const {
+  taco_iassert(this->defined());
+  return getMode().getModeFormat().impl->getCreatePosColoringEntry(getMode(), domainPoint, lowerBound, upperBound);
+}
+
+ir::Stmt Iterator::getFinalizePosColoring() const {
+  taco_iassert(this->defined());
+  return getMode().getModeFormat().impl->getFinalizePosColoring(getMode());
+}
+
+ModeFunction Iterator::getCreatePartitionWithPosColoring(ir::Expr domain, ir::Expr partitionColor) const {
+  taco_iassert(this->defined());
+  return getMode().getModeFormat().impl->getCreatePartitionWithPosColoring(getMode(), domain, partitionColor);
 }
 
 ModeFunction Iterator::getPartitionFromParent(ir::Expr parentPartition, ir::Expr partitionColor) const {

--- a/src/lower/mode_format_impl.cpp
+++ b/src/lower/mode_format_impl.cpp
@@ -291,7 +291,19 @@ Stmt ModeFormatImpl::getFinalizeYieldPos(Expr prevSize, Mode mode) const {
   return Stmt();
 }
 
-ModeFunction ModeFormatImpl::getCreateInitialPartition(Mode mode) const {
+Stmt ModeFormatImpl::getInitializePosColoring(Mode mode) const {
+  return Stmt();
+}
+
+Stmt ModeFormatImpl::getFinalizePosColoring(Mode mode) const {
+  return Stmt();
+}
+
+Stmt ModeFormatImpl::getCreatePosColoringEntry(Mode mode, Expr domainPoint, Expr lowerBound, Expr upperBound) const {
+  return Stmt();
+}
+
+ModeFunction ModeFormatImpl::getCreatePartitionWithPosColoring(Mode mode, Expr domain, Expr coloring) const {
   return ModeFunction();
 }
 


### PR DESCRIPTION
This commit performs a large overhaul of position space distribution by
introducing format abstractions for creating colorings and partitions
for distribution, unifying a large component of the implementation, as
well as increasing the flexibility of the current implementation. More
details can be found in comments of the source.