### PR TITLE
lower: use better heuristics for CPU load balancing of OpenMP loops

### DIFF
--- a/legion/spmv/taco-generated.cpp
+++ b/legion/spmv/taco-generated.cpp
@@ -692,7 +692,7 @@ void task_5(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
     return ;
 
   int64_t pointID1 = jposo;
-  #pragma omp parallel for schedule(static)
+  #pragma omp parallel for schedule(dynamic, 128)
   for (int32_t jposi = 0; jposi < ((((c1_pos_accessor[Point<1>(0)].hi + 1) - c1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces); jposi++) {
     int32_t jposc = (jposo * ((((c1_pos_accessor[Point<1>(0)].hi + 1) - c1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces) + jposi) + c1_pos_accessor[Point<1>(0)].lo;
     if (jposc >= (jposo + 1) * ((((c1_pos_accessor[Point<1>(0)].hi + 1) - c1_pos_accessor[Point<1>(0)].lo) + (pieces - 1)) / pieces) + c1_pos_accessor[Point<1>(0)].lo)

--- a/legion/spttv/taco-generated.cpp
+++ b/legion/spttv/taco-generated.cpp
@@ -506,7 +506,7 @@ void task_3(const Task* task, const std::vector<PhysicalRegion>& regions, Contex
   int32_t pB2_begin = B2PosDomain.bounds.lo;
   int32_t pB2_end = B2PosDomain.bounds.hi;
   int64_t pointID1 = ffposo;
-  #pragma omp parallel for schedule(static)
+  #pragma omp parallel for schedule(dynamic, 128)
   for (int32_t ffposio = 0; ffposio < (((B2Size + (pieces - 1)) / pieces + 2047) / 2048); ffposio++) {
     int64_t pointID2 = pointID1 * (((B2Size + (pieces - 1)) / pieces + 2047) / 2048) + ffposio;
     int32_t ffposi = ffposio * 2048;


### PR DESCRIPTION
This commit adjusts the OpenMP loop kind heuristics to only use
statically load balanced loops when it is gauranteed that each iteration
of the parallel loop will perform the same work.