### PR TITLE
*: implement Tensor Distribution Notation on dense tensors

### DIFF
--- a/include/taco/index_notation/index_notation.h
+++ b/include/taco/index_notation/index_notation.h
@@ -34,6 +34,7 @@ class Schedule;
 class Grid;
 class GridPlacement;
 class Transfer;
+class TensorDistributionNotation;
 
 class IndexVar;
 class WindowedIndexVar;
@@ -897,6 +898,7 @@ class Place : public IndexStmt {
 public:
   Place() = default;
   Place(IndexExpr e, std::vector<std::pair<Grid, GridPlacement>> placements);
+  Place(IndexExpr e, std::vector<TensorDistributionNotation> distribution);
   Place(const PlaceNode*);
 
   typedef PlaceNode Node;

--- a/include/taco/index_notation/index_notation_nodes.h
+++ b/include/taco/index_notation/index_notation_nodes.h
@@ -386,13 +386,17 @@ struct AssembleNode : public IndexStmtNode {
 
 struct PlaceNode : public IndexStmtNode {
   PlaceNode(IndexExpr e, std::vector<std::pair<Grid, GridPlacement>> placements) : expr(e), placements(placements) {}
+  PlaceNode(IndexExpr e, std::vector<TensorDistributionNotation> distribution) : expr(e), distribution(distribution) {}
 
   void accept(IndexStmtVisitorStrict* v) const {
     v->visit(this);
   }
 
   IndexExpr expr;
+  // Only one of placements and distribution should be set, and
+  // placements is deprecated.
   std::vector<std::pair<Grid, GridPlacement>> placements;
+  std::vector<TensorDistributionNotation> distribution;
 };
 
 struct PartitionNode : public IndexStmtNode {

--- a/include/taco/lower/lowerer_impl.h
+++ b/include/taco/lower/lowerer_impl.h
@@ -670,7 +670,19 @@ private:
   std::vector<TensorVar> tensorVarOrdering;
 
   bool isPlacementCode = false;
+  // Manages transferring information between the distribution syntax and
+  // the lowerer. This is set by the old distribution syntax.
   std::vector<std::pair<Grid, GridPlacement>> placements;
+  // Information about the Tensor Distribution Notation statement being lowered.
+  std::vector<TensorDistributionNotation> tensorDistributionNotation;
+  // getDataDistributionNestingDepth is a layer of indirection between the old
+  // and new notations for data distribution, allowing for the lowerer to understand
+  // which level of nested data distribution is being considered.
+  size_t getDataDistributionNestingDepth() {
+    taco_iassert(this->isPlacementCode);
+    taco_iassert(!this->placements.empty() || !this->tensorDistributionNotation.empty());
+    return std::max(this->placements.size(), this->tensorDistributionNotation.size());
+  }
 
   bool isPartitionCode = false;
 

--- a/legion/mttkrp/taco-generated.cpp
+++ b/legion/mttkrp/taco-generated.cpp
@@ -70,8 +70,8 @@ Legion::LogicalPartition partitionLegionA(Legion::Context ctx, Legion::Runtime* 
     }
     AColoring[(*itr)] = ARect;
   }
-  auto A_dense_run_0_Partition = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto A_vals_partition = copyPartition(ctx, runtime, A_dense_run_0_Partition, get_logical_region(A_vals));
+  IndexPartition A_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto A_vals_partition = copyPartition(ctx, runtime, A_dense_run_0_Partition_0, get_logical_region(A_vals));
   return A_vals_partition;
 }
 
@@ -100,8 +100,8 @@ Legion::LogicalPartition partitionLegionB(Legion::Context ctx, Legion::Runtime* 
     }
     BColoring[(*itr)] = BRect;
   }
-  auto B_dense_run_0_Partition = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto B_vals_partition = copyPartition(ctx, runtime, B_dense_run_0_Partition, get_logical_region(B_vals));
+  IndexPartition B_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto B_vals_partition = copyPartition(ctx, runtime, B_dense_run_0_Partition_0, get_logical_region(B_vals));
   return B_vals_partition;
 }
 
@@ -127,8 +127,8 @@ Legion::LogicalPartition partitionLegionC(Legion::Context ctx, Legion::Runtime* 
     }
     CColoring[(*itr)] = CRect;
   }
-  auto C_dense_run_0_Partition = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto C_vals_partition = copyPartition(ctx, runtime, C_dense_run_0_Partition, get_logical_region(C_vals));
+  IndexPartition C_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto C_vals_partition = copyPartition(ctx, runtime, C_dense_run_0_Partition_0, get_logical_region(C_vals));
   return C_vals_partition;
 }
 
@@ -154,8 +154,8 @@ Legion::LogicalPartition partitionLegionD(Legion::Context ctx, Legion::Runtime* 
     }
     DColoring[(*itr)] = DRect;
   }
-  auto D_dense_run_0_Partition = runtime->create_index_partition(ctx, D_dense_run_0, domain, DColoring, LEGION_DISJOINT_COMPLETE_KIND);
-  auto D_vals_partition = copyPartition(ctx, runtime, D_dense_run_0_Partition, get_logical_region(D_vals));
+  IndexPartition D_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, D_dense_run_0, domain, DColoring, LEGION_DISJOINT_COMPLETE_KIND);
+  auto D_vals_partition = copyPartition(ctx, runtime, D_dense_run_0_Partition_0, get_logical_region(D_vals));
   return D_vals_partition;
 }
 
@@ -183,12 +183,12 @@ partitionPackForplaceLegionA partitionForplaceLegionA(Legion::Context ctx, Legio
     }
     AColoring[(*itr)] = ARect;
   }
-  auto A_dense_run_0_Partition = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_COMPUTE_KIND);
-  auto A_vals_partition = copyPartition(ctx, runtime, A_dense_run_0_Partition, get_logical_region(A_vals));
+  IndexPartition A_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_COMPUTE_KIND);
+  auto A_vals_partition = copyPartition(ctx, runtime, A_dense_run_0_Partition_0, get_logical_region(A_vals));
   computePartitions.APartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(2);
   computePartitions.APartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions.APartition.valsPartition = A_vals_partition;
-  computePartitions.APartition.denseLevelRunPartitions[0] = A_dense_run_0_Partition;
+  computePartitions.APartition.denseLevelRunPartitions[0] = A_dense_run_0_Partition_0;
 
   return computePartitions;
 }
@@ -260,12 +260,12 @@ partitionPackForplaceLegionB partitionForplaceLegionB(Legion::Context ctx, Legio
     }
     BColoring[(*itr)] = BRect;
   }
-  auto B_dense_run_0_Partition = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_COMPUTE_KIND);
-  auto B_vals_partition = copyPartition(ctx, runtime, B_dense_run_0_Partition, get_logical_region(B_vals));
+  IndexPartition B_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_COMPUTE_KIND);
+  auto B_vals_partition = copyPartition(ctx, runtime, B_dense_run_0_Partition_0, get_logical_region(B_vals));
   computePartitions.BPartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(3);
   computePartitions.BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(3);
   computePartitions.BPartition.valsPartition = B_vals_partition;
-  computePartitions.BPartition.denseLevelRunPartitions[0] = B_dense_run_0_Partition;
+  computePartitions.BPartition.denseLevelRunPartitions[0] = B_dense_run_0_Partition_0;
 
   return computePartitions;
 }
@@ -327,12 +327,12 @@ partitionPackForplaceLegionC partitionForplaceLegionC(Legion::Context ctx, Legio
     }
     CColoring[(*itr)] = CRect;
   }
-  auto C_dense_run_0_Partition = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_COMPUTE_KIND);
-  auto C_vals_partition = copyPartition(ctx, runtime, C_dense_run_0_Partition, get_logical_region(C_vals));
+  IndexPartition C_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_COMPUTE_KIND);
+  auto C_vals_partition = copyPartition(ctx, runtime, C_dense_run_0_Partition_0, get_logical_region(C_vals));
   computePartitions.CPartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(2);
   computePartitions.CPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions.CPartition.valsPartition = C_vals_partition;
-  computePartitions.CPartition.denseLevelRunPartitions[0] = C_dense_run_0_Partition;
+  computePartitions.CPartition.denseLevelRunPartitions[0] = C_dense_run_0_Partition_0;
 
   return computePartitions;
 }
@@ -401,12 +401,12 @@ partitionPackForplaceLegionD partitionForplaceLegionD(Legion::Context ctx, Legio
     }
     DColoring[(*itr)] = DRect;
   }
-  auto D_dense_run_0_Partition = runtime->create_index_partition(ctx, D_dense_run_0, domain, DColoring, LEGION_COMPUTE_KIND);
-  auto D_vals_partition = copyPartition(ctx, runtime, D_dense_run_0_Partition, get_logical_region(D_vals));
+  IndexPartition D_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, D_dense_run_0, domain, DColoring, LEGION_COMPUTE_KIND);
+  auto D_vals_partition = copyPartition(ctx, runtime, D_dense_run_0_Partition_0, get_logical_region(D_vals));
   computePartitions.DPartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(2);
   computePartitions.DPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions.DPartition.valsPartition = D_vals_partition;
-  computePartitions.DPartition.denseLevelRunPartitions[0] = D_dense_run_0_Partition;
+  computePartitions.DPartition.denseLevelRunPartitions[0] = D_dense_run_0_Partition_0;
 
   return computePartitions;
 }
@@ -512,30 +512,30 @@ partitionPackForcomputeLegion partitionForcomputeLegion(Legion::Context ctx, Leg
     }
     DColoring[(*itr)] = DRect;
   }
-  auto A_dense_run_0_Partition = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_COMPUTE_KIND);
-  auto A_vals_partition = copyPartition(ctx, runtime, A_dense_run_0_Partition, get_logical_region(A_vals));
-  auto B_dense_run_0_Partition = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_COMPUTE_KIND);
-  auto B_vals_partition = copyPartition(ctx, runtime, B_dense_run_0_Partition, get_logical_region(B_vals));
-  auto C_dense_run_0_Partition = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_COMPUTE_KIND);
-  auto C_vals_partition = copyPartition(ctx, runtime, C_dense_run_0_Partition, get_logical_region(C_vals));
-  auto D_dense_run_0_Partition = runtime->create_index_partition(ctx, D_dense_run_0, domain, DColoring, LEGION_COMPUTE_KIND);
-  auto D_vals_partition = copyPartition(ctx, runtime, D_dense_run_0_Partition, get_logical_region(D_vals));
+  IndexPartition A_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, A_dense_run_0, domain, AColoring, LEGION_COMPUTE_KIND);
+  auto A_vals_partition = copyPartition(ctx, runtime, A_dense_run_0_Partition_0, get_logical_region(A_vals));
+  IndexPartition B_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, B_dense_run_0, domain, BColoring, LEGION_COMPUTE_KIND);
+  auto B_vals_partition = copyPartition(ctx, runtime, B_dense_run_0_Partition_0, get_logical_region(B_vals));
+  IndexPartition C_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, C_dense_run_0, domain, CColoring, LEGION_COMPUTE_KIND);
+  auto C_vals_partition = copyPartition(ctx, runtime, C_dense_run_0_Partition_0, get_logical_region(C_vals));
+  IndexPartition D_dense_run_0_Partition_0 = runtime->create_index_partition(ctx, D_dense_run_0, domain, DColoring, LEGION_COMPUTE_KIND);
+  auto D_vals_partition = copyPartition(ctx, runtime, D_dense_run_0_Partition_0, get_logical_region(D_vals));
   computePartitions.APartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(2);
   computePartitions.APartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions.APartition.valsPartition = A_vals_partition;
-  computePartitions.APartition.denseLevelRunPartitions[0] = A_dense_run_0_Partition;
+  computePartitions.APartition.denseLevelRunPartitions[0] = A_dense_run_0_Partition_0;
   computePartitions.BPartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(3);
   computePartitions.BPartition.denseLevelRunPartitions = std::vector<IndexPartition>(3);
   computePartitions.BPartition.valsPartition = B_vals_partition;
-  computePartitions.BPartition.denseLevelRunPartitions[0] = B_dense_run_0_Partition;
+  computePartitions.BPartition.denseLevelRunPartitions[0] = B_dense_run_0_Partition_0;
   computePartitions.CPartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(2);
   computePartitions.CPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions.CPartition.valsPartition = C_vals_partition;
-  computePartitions.CPartition.denseLevelRunPartitions[0] = C_dense_run_0_Partition;
+  computePartitions.CPartition.denseLevelRunPartitions[0] = C_dense_run_0_Partition_0;
   computePartitions.DPartition.indicesPartitions = std::vector<std::vector<Legion::LogicalPartition>>(2);
   computePartitions.DPartition.denseLevelRunPartitions = std::vector<IndexPartition>(2);
   computePartitions.DPartition.valsPartition = D_vals_partition;
-  computePartitions.DPartition.denseLevelRunPartitions[0] = D_dense_run_0_Partition;
+  computePartitions.DPartition.denseLevelRunPartitions[0] = D_dense_run_0_Partition_0;
 
   return computePartitions;
 }

--- a/src/codegen/codegen_legion_c.cpp
+++ b/src/codegen/codegen_legion_c.cpp
@@ -212,7 +212,7 @@ ir::Stmt CodegenLegionC::simplifyFunctionBodies(ir::Stmt stmt) {
     // loop a few times of simplification before calling it.
     void visit(const Function* func) {
       ir::Stmt body = func->body;
-      for (int i = 0; i < 5; i++) {
+      for (int i = 0; i < 10; i++) {
         body = ir::simplify(body);
       }
       stmt = Function::make(func->name, func->outputs, func->inputs, body, func->returnType);

--- a/src/index_notation/distribution.cpp
+++ b/src/index_notation/distribution.cpp
@@ -36,4 +36,110 @@ PlacementGrid::Axis operator|(ir::Expr e, GridPlacement::AxisMatch axis) {
   return PlacementGrid::Axis(e, axis);
 }
 
+struct DistVar::Content {
+  std::string name;
+};
+
+DistVar::DistVar() : content(new Content) {
+  this->content->name = "random_name";
+}
+
+DistVar::DistVar(const std::string &name) : content(new Content) {
+  this->content->name = name;
+}
+
+const std::string& DistVar::getName() const {
+  return this->content->name;
+}
+
+bool operator==(const DistVar& a, const DistVar& b) {
+  return a.content == b.content;
+}
+
+bool operator<(const DistVar& a, const DistVar& b) {
+  return a.content < b.content;
+}
+
+struct MachineDimensionName::Content {
+  Kind kind;
+  // Used when kind == Var.
+  DistVar var;
+  // Used when kind == Restriction.
+  int restriction;
+};
+
+MachineDimensionName::MachineDimensionName(int n) : content(new Content) {
+  this->content->kind = Restriction;
+  this->content->restriction = n;
+}
+
+MachineDimensionName::MachineDimensionName(DistVar v) : content(new Content) {
+  this->content->kind = Var;
+  this->content->var = v;
+}
+
+MachineDimensionName::MachineDimensionName() : content(nullptr) {}
+
+MachineDimensionName MachineDimensionName::broadcast() {
+  MachineDimensionName name;
+  name.content = std::make_shared<MachineDimensionName::Content>();
+  name.content->kind = Broadcast;
+  return name;
+}
+
+MachineDimensionName::Kind MachineDimensionName::getKind() const {
+  return this->content->kind;
+}
+
+const DistVar MachineDimensionName::getDistVar() const {
+  taco_iassert(this->getKind() == Var);
+  return this->content->var;
+}
+
+int MachineDimensionName::getRestriction() const {
+  taco_iassert(this->getKind() == Restriction);
+  return this->content->restriction;
+}
+
+struct TensorDistributionNotation::Content {
+  std::vector<DistVar> lhs;
+  std::vector<MachineDimensionName> rhs;
+  Grid machine;
+  ParallelUnit pu;
+};
+
+TensorDistributionNotation::TensorDistributionNotation() : content(nullptr) {}
+
+bool TensorDistributionNotation::isValid() const {
+  return this->content != nullptr;
+}
+
+TensorDistributionNotation::TensorDistributionNotation(std::vector<DistVar> lhs, Grid machine,
+                                                       std::vector<MachineDimensionName> rhs,
+                                                       ParallelUnit pu) : content(new Content) {
+  this->content->lhs = lhs;
+  this->content->rhs = rhs;
+  this->content->machine = machine;
+  this->content->pu = pu;
+}
+
+const std::vector<MachineDimensionName>& TensorDistributionNotation::getRHS() const {
+  taco_iassert(this->isValid());
+  return this->content->rhs;
+}
+
+const std::vector<DistVar>& TensorDistributionNotation::getLHS() const {
+  taco_iassert(this->isValid());
+  return this->content->lhs;
+}
+
+const Grid& TensorDistributionNotation::getMachine() const {
+  taco_iassert(this->isValid());
+  return this->content->machine;
+}
+
+ParallelUnit TensorDistributionNotation::getParallelUnit() const {
+  return this->content->pu;
+}
+
 }

--- a/src/index_notation/index_notation.cpp
+++ b/src/index_notation/index_notation.cpp
@@ -2225,6 +2225,8 @@ template <> Assemble to<Assemble>(IndexStmt s) {
 
 Place::Place(IndexExpr e, std::vector<std::pair<Grid, GridPlacement>> placements) : Place(new PlaceNode(e, placements)) {}
 
+Place::Place(IndexExpr e, std::vector<TensorDistributionNotation> distribution) : Place(new PlaceNode(e, distribution)) {}
+
 Place::Place(const PlaceNode * n) : IndexStmt(n) {}
 
 Partition::Partition(Access a) : Partition(new PartitionNode(a)) {}

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -86,7 +86,19 @@ TensorBase::TensorBase(std::string name, Datatype ctype, std::vector<int> dimens
   this->content->distribution = distribution;
 }
 
-static Format initFormat(Format format) {
+TensorBase::TensorBase(std::string name, Datatype ctype, std::vector<int> dimensions, Format format,
+                       TensorDistributionNotation distribution) :
+                       TensorBase(name, ctype, dimensions, format) {
+  this->content->tensorDistributionNotation = {distribution};
+}
+
+TensorBase::TensorBase(std::string name, Datatype ctype, std::vector<int> dimensions, Format format,
+                       std::vector<TensorDistributionNotation> distribution) :
+    TensorBase(name, ctype, dimensions, format) {
+  this->content->tensorDistributionNotation = distribution;
+}
+
+  static Format initFormat(Format format) {
   // Initialize coordinate types for Format if not already set
   if (format.getLevelArrayTypes().size() < (size_t)format.getOrder()) {
     std::vector<std::vector<Datatype>> levelArrayTypes;
@@ -1595,6 +1607,154 @@ IndexStmt TensorBase::getPlacementStatement() {
                                                             d.parUnit});
   }
   return this->placeHierarchy(result);
+}
+
+IndexStmt TensorBase::translateDistribution() {
+  // A vector of aesthetic index variable names for the generated code.
+  std::vector<std::string> ivarNames {"i", "j", "k", "l", "m", "n", "o", "p", "q"};
+  size_t idx = 0;
+  auto freshName = [&]() {
+    taco_iassert(idx < ivarNames.size());
+    auto res = ivarNames[idx];
+    idx++;
+    return res;
+  };
+  assert(size_t(this->getOrder()) <= ivarNames.size());
+  std::vector<TensorDistributionNotation> distributions = this->content->tensorDistributionNotation;
+
+  // All of the LHS name vectors should index all tensor dimensions.
+  for (auto dist : distributions) {
+    taco_uassert(dist.isValid());
+    taco_uassert(dist.getLHS().size() == size_t(this->getOrder()));
+    taco_uassert(dist.getRHS().size() == size_t(dist.getMachine().getDim()));
+  }
+
+  // We need variables for each variable in the tensor.
+  int numVars = this->getOrder();
+  assert(size_t(numVars) <= ivarNames.size());
+  std::vector<IndexVar> currentVars;
+  for (int i = 0; i < numVars; i++) {
+    currentVars.push_back(IndexVar(freshName()));
+  }
+  // For each distribution, we need fresh variables for unconstrained
+  // dimensions of each placement. These variables allow for replication
+  // across an axis of the processor grid and are importantly not contained
+  // within the access.
+  std::vector<std::vector<IndexVar>> unconstrainedVars(distributions.size());
+  for (size_t i = 0; i < distributions.size(); i++) {
+    auto d = distributions[i];
+    for (const auto& name : d.getRHS()) {
+      // Here we have to check that the axis is either replicated,
+      // restricted, or if the name doesn't appear in the RHS.
+      if (name.getKind() == MachineDimensionName::Broadcast ||
+          name.getKind() == MachineDimensionName::Restriction ||
+          (name.getKind() == MachineDimensionName::Var
+           && !util::contains(d.getLHS(), name.getDistVar()))) {
+        auto var = IndexVar(freshName());
+        unconstrainedVars[i].push_back(var);
+        currentVars.push_back(var);
+      }
+    }
+  }
+
+  // We choose the first getOrder() variables to be used in the access.
+  std::vector<IndexVar> accessVars;
+  for (int i = 0; i < this->getOrder(); i++) {
+    accessVars.push_back(currentVars[i]);
+  }
+
+  // Build the base statement that we will manipulate with scheduling
+  // commands to construct the specified distribution.
+  auto base = Access(this->getTensorVar(), accessVars);
+  IndexStmt stmt = Place(base, distributions);
+  for (const auto& var : currentVars) {
+    stmt = forall(var, stmt);
+  }
+
+  // Now apply all of the scheduling transformations required by
+  // the Tensor Distribution Notation statement.
+  for (size_t i = 0; i < distributions.size(); i++) {
+    auto dist = distributions[i];
+
+    // Construct a mapping between the access variables and the DistVars
+    // for each level.
+    std::map<DistVar, IndexVar> accessVarMapping;
+    for (size_t j = 0; j < dist.getLHS().size(); j++) {
+      accessVarMapping[dist.getLHS()[j]] = accessVars[j];
+    }
+
+    // First, we'll select the variables that need to be distributed
+    // and order them to the front of the statement.
+    std::vector<IndexVar> ordering;
+    std::set<IndexVar> reordered;
+    int numUnconstrainedVars = 0;
+    for (size_t j = 0; j < dist.getRHS().size(); j++) {
+      auto name = dist.getRHS()[j];
+      if (name.getKind() == MachineDimensionName::Var) {
+        // If this variable partitions a tensor dimension, then
+        // it is distributed.
+        if (util::contains(dist.getLHS(), name.getDistVar())) {
+          auto ivar = accessVarMapping[name.getDistVar()];
+          ordering.push_back(ivar);
+          reordered.insert(ivar);
+        }
+      } else if (name.getKind() == MachineDimensionName::Restriction ||
+                 name.getKind() == MachineDimensionName::Broadcast) {
+        // Otherwise, use a fresh variable that isn't in the access, since this
+        // dimension is unconstrained.
+        auto ivar = unconstrainedVars[i][numUnconstrainedVars];
+        numUnconstrainedVars++;
+        ordering.push_back(ivar);
+        reordered.insert(ivar);
+      } else {
+        taco_iassert(false);
+      }
+    }
+    // Finally insert all remaining variables to the ordering.
+    for (auto v : currentVars) {
+      if (!util::contains(reordered, v)) {
+        ordering.push_back(v);
+      }
+    }
+    // Reorder the variables so that the variables we are distributing
+    // are all at the front.
+    stmt = stmt.reorder(ordering);
+
+    // Utility function to find the index of a variable in a vector. Returns
+    // -1 if the variable is not found.
+    auto idxOf = [&](IndexVar var, std::vector<IndexVar> vars) {
+      for (size_t j = 0; j < vars.size(); j++) {
+        if (vars[j] == var) {
+          return int(j);
+        }
+      }
+      return -1;
+    };
+
+    // Finally, distribute all of the variables we are supposed to
+    // and update the "current" set of variables for the recursion.
+    std::vector<IndexVar> original, distributed, local;
+    for (int j = 0; j < dist.getMachine().getDim(); j++) {
+      auto ivar = ordering[j];
+      original.push_back(ivar);
+      distributed.push_back(IndexVar(ivar.getName() + "n"));
+      local.push_back(IndexVar(ivar.getName() + "l"));
+
+      // Replace the variables in currentVars and accessVars.
+      int curIdx = idxOf(ivar, currentVars);
+      taco_iassert(curIdx != -1);
+      currentVars[curIdx] = local[j];
+      // Not all variables being distributed will be part of accessVars.
+      int accessIdx = idxOf(ivar, accessVars);
+      if (accessIdx != -1) {
+        accessVars[accessIdx] = local[j];
+      }
+    }
+    stmt = stmt.distribute(original, distributed, local, dist.getMachine(), dist.getParallelUnit());
+    stmt = stmt.communicate(base, distributed.back());
+  }
+
+  return stmt;
 }
 
 }


### PR DESCRIPTION
This commit implements a large amount of Tensor Distribution Notation
as described in the DISTAL paper, and begins the phasing out of the
old notation for distribution.